### PR TITLE
Fixing the dirty fix and some compile errors

### DIFF
--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -4,7 +4,6 @@
 <!ENTITY rfc3031 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3031.xml">
 <!ENTITY rfc3032 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3032.xml">
 <!ENTITY rfc3985 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3985.xml">
-<!ENTITY rfc4023 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4023.xml">
 <!ENTITY rfc4090 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4090.xml">
 <!ENTITY rfc4385 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4385.xml">
 <!ENTITY rfc4446 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4446.xml">
@@ -29,7 +28,6 @@
 <!ENTITY rfc5085 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5085.xml">
 <!ENTITY rfc5921 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5921.xml">
 <!ENTITY rfc5960 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5960.xml">
-<!ENTITY rfc6073 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6073.xml">
 <!ENTITY rfc6275 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6275.xml">
 <!ENTITY rfc6371 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6371.xml">
 <!ENTITY rfc6373 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6373.xml">
@@ -54,8 +52,6 @@
 <!ENTITY I-D.ietf-detnet-problem-statement PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-problem-statement.xml">
 <!ENTITY I-D.ietf-detnet-architecture PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-architecture.xml">
 <!ENTITY I-D.ietf-mpls-residence-time SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-mpls-residence-time">
-
-<!ENTITY I-D.ietf-6man-segment-routing-header PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-6man-segment-routing-header.xml">
 
 ]>
 
@@ -292,20 +288,23 @@
   <figure align="center" anchor="fig_8021_detnet"
   title="IEEE 802.1TSN over DetNet">
   <artwork><![CDATA[
-     TSN    |<---------- End to End DetNet Service ------>|  TSN
-    Service |           Transit           Transit         | Service
-TSN  (AC)   |        |<-Tunnel->|        |<-Tnl->|        |  (AC)  TSN
-End    |    V        V     1    V        V   2   V        V   |    End
-System |    +--------+          +--------+       +--------+   |  System
-+---+  |    |   E1   |==========|   R1   |=======|   E2   |   |   +---+
-|   |--|----|._X_....|..DetNet..|.._ _...|..DF3..|...._X_.|---|---|   |
-|CE1|  |    |    \   |  Flow 1  |   X    |       |   /    |   |   |CE2|
-|   |       |     \_.|...DF2....|._/ \_..|..DF4..|._/     |       |   |
-+---+       |        |==========|        |=======|        |       +---+
-    ^       +--------+          +--------+       +--------+       ^
-    |        Edge Node          Relay Node       Edge Node        |
+     TSN    |<------- End to End DetNet Service ------>|  TSN
+    Service |         Transit          Transit         | Service
+TSN  (AC)   |        |<-Tnl->|        |<-Tnl->|        |  (AC)  TSN
+End    |    V        V    1  V        V   2   V        V   |    End
+System |    +--------+       +--------+       +--------+   |  System
++---+  |    |   E1   |=======|   R1   |=======|   E2   |   |   +---+
+|   |--|----|._X_....|..DF1..|.._ _...|..DF3..|...._X_.|---|---|   |
+|CE1|  |    |    \   |       |   X    |       |   /    |   |   |CE2|
+|   |       |     \_.|..DF2..|._/ \_..|..DF4..|._/     |       |   |
++---+       |        |=======|        |=======|        |       +---+
+    ^       +--------        +--------+       +--------+       ^
+    |        Edge Node       Relay Node       Edge Node        |
     |                                                             |
     |<----- Emulated Time Sensitive Networking (TSN) Service ---->|
+
+    DFx = DetNet Flow x
+
 ]]>
 </artwork>
 </figure>
@@ -765,23 +764,23 @@ Examples
   <figure title="Optimal replication and elimination placement across technology segments example" anchor="fig_pref_xcrs_segments">
   <artwork align="center"><![CDATA[
                                    ______   
-                         _____    /      \__ 
-            ____        /     \__/          \___    ______
-+----+   __/    +======+                        +==+      \     +----+
-|src |__/  Seg1  )     |                        |  \  Seg3 \____| dst|
-+----+  \_______+      \        Segment-2       |   \+_____/    +----+
-                 \======+__                    _+===/
-                           \         __     __/
-                            \_______/  \___/
+                         ____     /      \__ 
+            ____        /     \__/          \___   ______
++----+   __/    +======+                       +==+      \     +----+
+|src |__/  Seg1  )     |                       |  \  Seg3 \____| dst|
++----+  \_______+      \       Segment-2       |   \+_____/    +----+
+                 \======+_                    _+===/
+                          \         __     __/
+                           \_______/  \___/
 
 
-                                          +------------+
-             +------------------E----+    |            |
-+----+       |                  |    +----R---+        |          +----+
-|src |-------R              +---+             |        E----------+ dst|
-+----+       |              |                 E--------+          +----+
-             +--------------R                 |
-                            +-----------------+
+                                       +------------+
+             +---------------E----+    |            |
++----+       |               |    +----R---+        |          +----+
+|src |-------R           +---+             |        E----------+ dst|
++----+       |           |                 E--------+          +----+
+             +-----------R                 |
+                         +-----------------+
   ]]>
     </artwork></figure>
 
@@ -967,10 +966,38 @@ Placeholder
    <section title="Indication of the DetNet Payload Type" anchor="PTI-section">
    <t>
     The only nodes that needs to know the payload type of a flow are the
-    DetNet ingress node and the DetNet egress nodes.
-    The ingress node has to know how to process the packet it receives
-    from the ingress AC, and egress edge node has to know how to..
+    DetNet ingress node and the DetNet egress nodes.  The ingress node
+    has to know how to process the packet it receives from the ingress
+    AC, and egress edge node has to know how to prepare the packet for
+    transmission on the egress AC.
    </t>	   
+   <t>
+    On ingress a DetNet edge node has to classify the packets into those
+    that are for transmission as Detnet packets and those that are for
+    transmission as "normal" packets at one of more lower priorities.
+    The packet type is indicated to the egress edge node through the
+    value of the S-label.  Thus, when the egress edge node looks up the
+    S-label one of the parameters returned is the packet type which in
+    turn tells the egress edge node how to prepare the packet for
+    transmission over the egress AC.
+   </t>
+   <t>
+    The consequence of this approach is that if multiple packet
+    encapsulations are processed on a node, each will need its own
+    S-Label.  That is not generally a problems, since it is anticipated
+    that only one encapsulation type intented for carriage as a DetNet
+    flow will be present on any egress.  However, IPv4 and IPv6 have
+    different forwarding equivalence classes (FEC) in MPLS and are
+    therefore allocated different labels rather than being distinguished
+    through the IP version field in the IP header.  Futhermore IPv4 and
+    IPv6 when running directly over Ethernet are identified via the
+    Ethertype rather than via the IP version number.  Whilst it ought to
+    be safe to identify the IP type though the IP version number the
+    absence this approach in practical applications suggests that it is
+    more conservative to distinguish between IP types through the
+    S-Label.  Thus when the payload is IP, two S-Labels are used, one to
+    identify an IPv4 payload and one to identify an IPv6 payload.
+   </t>
 	   
    <t>
     <list>
@@ -1762,7 +1789,7 @@ Client AC   |             |           |             |
 
   <t>When DetNet is used, there is an underlying assumption that the
   applicaton(s) require clock synchronization such as the Precision Time Protocol
-  (PTP) [IEEE1588]. The relay nodes may or may not utilize clock synchronization
+  (PTP)  <xref target="IEEE1588"/>. The relay nodes may or may not utilize clock synchronization
   in order to provide zero congestion loss and controlled latency delivery.  In either case, there are a
   few possible approaches of
   how synchronization protocol packets are forwarded and handled by the
@@ -2041,12 +2068,9 @@ Client AC   |             |           |             |
    <?rfc include="reference.RFC.5085"?>
    <?rfc include="reference.RFC.5462"?>
    <?rfc include="reference.RFC.6003"?>
-   &rfc6073;
    &rfc4385;
-   &rfc4023;
    &rfc7510;
    &I-D.ietf-spring-segment-routing-mpls;
-   <?rfc include="reference.RFC.8200"?>
   </references>
   <references title="Informative references">
    <?rfc include="reference.RFC.2205"?>
@@ -2057,7 +2081,6 @@ Client AC   |             |           |             |
    <?rfc include="reference.RFC.8040"?>
    &I-D.ietf-detnet-dp-alt;
    &I-D.ietf-detnet-architecture;
-   &I-D.ietf-6man-segment-routing-header;
 
    <reference anchor='I-D.sdt-detnet-security'>
     <front>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -634,17 +634,18 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
     </artwork></figure>
   
 
- <section title="DetNet Bridging Service">
+ <section title="DetNet Layer Two Service">
   
   <t>
-   The simplest DetNet service is to provide bridging (i.e., tunneling for L2),
+   The simplest DetNet service is to provide tunneling for layer two,
    where the connected hosts are in the same broadcast (BC) domain. Forwarding
-   over the DetNet domain is based on L2 (MAC) addresses (i.e. dst-MAC), so L2
-   headers MUST be kept. For both IP and MPLS PSN a DetNet specific tunnel
-   encapsulation MUST be introduced. 
+   over the DetNet domain is based on L2 (MAC) addresses (i.e. dst-MAC),
+   or on received interface <xref target="RFC3985"/>. In both cases
+   the L2 headers MUST either be kept, or provision must be made for their
+   reconstruction at egress from the DetNet domain.
   </t>
 
-  <figure title="Encapsulation format for DetNet Bridging" anchor="fig_encap_DN_bridging">
+  <figure title="Encapsulation format for DetNet Layer Two Service" anchor="fig_encap_DN_bridging">
   <artwork align="center"><![CDATA[
                      +------+
                      |  X   |
@@ -652,43 +653,48 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
             |  X   | |  IP  |
             +------+ +------+
 End+system  |  L2  | |  L2  |
-      +-----+======+-+======+--+======+-+======++
-DetNet tunnel                  |  IP  | | MPLS |
-                               +------+ +------+
-                               |  L2  | |  L2  |
-                               +------+ +------+
+      +-----+======+-+======+--+------+
+DetNet tunnel                  | Shim |
+                               +------+ 
+                               | MPLS |
+                               +------+
+                               |  L2  |
+                               +------+
 
 Examples
 
-                               +------+ +------+
-                               |  X   | |  X   |
-            +------+ +------+  +------+ +------+
-            |  X   | |  X   |  |  IP  | |  IP  |
-            +------+ +------+  +------+ +------+
-            |  L2  | |  L2  |  |  L2  | |  L2  |
-           ++======+-+======+--+======+-+======++
-            |  IP  | | MPLS |  |  IP  | | MPLS |
-            +------+ +------+  +------+ +------+
-            |  L2  | |  L2  |  |  L2  | |  L2  |
-            +------+ +------+  +------+ +------+
+                      +------+  +------+
+                      |  X   |  |  X   |
+            +------+  +------+  +------+
+            |  X   |  |  IP  |  |  IP  | 
+            +------+  +------+  +------+
+            |  L2  |  |  L2  |  |  L2  |
+            +======+--+======+--+======+
+            | d-CW |  | d-CW |  | d-CW |
+            +------+  +------+  +------+
+            | MPLS |  | MPLS |  | MPLS |
+            +------+  +------+  +------+
+            |  L2  |  |  L2  |  | UDP  |  
+            +------+  +------+  +------+
+                                |  IP  |
+                                +------+
+                                |  L2  |
+                                +------+
   ]]>
     </artwork></figure>
   
   <t>
-   As shown on the figure both L2 and L3 end-systems can be served by such a DetNet Bridging service.   
+   As shown on the figure both L2 and L3 end-systems can be served by such a DetNet layer two encapsulation service.
+   This encapsulation service may be carried over MPLS natively  <xref target="pwSolution"/>, of over MPLS over IP
+   <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>   
   </t>
   </section>
 
  <section title="DetNet Routing Service" anchor="detrouting">
 
   <t> 
-   DetNet Routing service provides routing, therefore available only for L3
-   hosts that are in different BC domains. Forwarding over the DetNet domain is
-   based on L3 (IP) addresses (i.e. dst-IP).
-  </t>
-
-  <section title="MPLS PSN">
-  <t> 
+   DetNet Routing service provides routing. Forwarding over the DetNet domain is
+   based on L3 (IP) addresses (i.e. dst-IP). 
    In case of an MPLS PSN at the ingress/egress (i.e., PE nodes of DetNet
    domain) the IP packets are encapsulated in MPLS. The data-flow IP header MUST
    be preserved as-is. 
@@ -696,20 +702,41 @@ Examples
 
   <figure title="Encapsulation format for DetNet Routing in MPLS PSN for L3 end-systems" anchor="fig_mpls_DN_routing">
   <artwork align="center"><![CDATA[
-           +------+                         +------+
-           |  X   |                         |  X   |
-           +------+                         +------+
-End+system |  IP  |                         |  IP  |
-      -----+------+-------+======+---     --+======+--
-DetNet                    | MPLS |          | MPLS |
-                          +------+          +------+
-                          |  L2  |          |  L2  |
-                          +------+          +------+
+            
+            
+            +------+
+            |  X   |
+            +------+
+End+system  |  IP  |
+      +-----+======+--+------+
+DetNet tunnel         | Shim |
+                      +------+ 
+                      | MPLS |
+                      +------+
+                      |  L2  |
+                      +------+
+
+Examples
+
+            +------+  +------+
+            |  X   |  |  X   |
+            +------+  +------+
+            |  IP  |  |  IP  | 
+            +======+--+======+
+            | d-CW |  | d-CW |
+            +------+  +------+
+            | MPLS |  | MPLS |
+            +------+  +------+
+            |  L2  |  | UDP  |  
+            +------+  +------+
+                      |  IP  |
+                      +------+
+                      |  L2  |
+                      +------+
   ]]>
-    </artwork></figure>
-  
-  </section>
- </section> <!-- -->
+  </artwork></figure>
+ 
+ </section>
 </section>
 
   

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -926,7 +926,132 @@ Placeholder
    </t>
   </section>
 
-   <section title="Service layer considerations">
+  <section anchor="FAG" title="Flow Aggregation">
+   <t>
+    The ability to aggregate individual flows, and their associated
+    resource control, into a larger aggregate is an important technique
+    for improving scaling of control in the data, management and control
+    planes.  The DetNet data plane allows for the aggregation of DetNet flows,
+    to improved scaling. There are three methods of introducing flow aggregation:
+   </t>
+   <t>
+    <list style="numbers">
+     <t>Aggregate at the LSP (Transport)</t>
+     <t>Aggregating DetNet flows as a new DetNet flow</t>
+     <t>Simple Aggregation at the DetNet layer</t>
+    </list>
+   </t>
+   <t>
+    A further method of using SR to perform aggregation is for further study.
+   </t>
+   <t>
+    The resource control and
+    management aspects of aggregation (including the queuing/shaping/
+    policing implications) will be covered in other documents.
+   </t>
+  </section>
+  <section anchor="aggregation-at-the-lsp" title="Aggregation at the LSP">
+   <t>
+    DetNet flows transported via MPLS can leverage MPLS-TE?s existing
+    support for hierarchical LSPs (H-LSPs), see <xref target="RFC4206"/>.  H-LSPs are
+    typically used to aggregate control and resources, they may also be
+    used to provide OAM or protection for the aggregated LSPs.  Arbitrary
+    levels of aggregation naturally falls out of the definition for
+    hierarchy and the MPLS label stack <xref target="RFC3032"/>.  DetNet nodes which
+    support aggregation (LSP hierarchy) map one or more LSPs (labels)
+    into and from an H-LSP.  Both carried LSPs and H-LSPs may or may not
+    use the TC field, i.e., L-LSPs or E-LSPs.  Such nodes will need to
+    ensure that traffic from aggregated LSPs are placed (shaped/policed/
+    enqueued) onto the H-LSPs in a fashion that ensures the required
+    DetNet service is preserved.
+   </t>
+   <t>
+    Additional details of the traffic
+    control capabilities needed at a DetNet-aware node may be covered in
+    the new service descriptions mentioned above or in separate future
+    documents.  Management and control plane mechanisms will also need to
+    ensure that the service required on the aggregate flow (H-LSP or
+    DSCP) are provided, which may include the discarding or remarking
+    mentioned in the previous sections.
+   </t>
+  </section>
+  <section anchor="aggregating-detnet-flows-as-a-new-detnet-flow" title="Aggregating DetNet flows as a new DetNet flow">
+   <t>
+    An aggregate can be built by layering DetNet flows as shown below:
+   </t>
+
+<figure><artwork><![CDATA[
++---------------------------------+
+|                                 |
+|           DetNet Flow           |
+|         Payload  Packet         |
+|                                 |
++---------------------------------+ <--\
+|       DetNet Control Word       |    |
++=================================+    |
+|            S-Label              |    |    
++---------------------------------+    +----DetNet data plane
+|       DetNet Control Word       |    |    MPLS encapsulation
++=================================+    |
+|            A-Label              |    |
++---------------------------------+ <--/
+|           T-Label(s)            |
++---------------------------------+
+|           Data-Link             |
++---------------------------------+
+|           Physical              |
++---------------------------------+
+]]></artwork></figure>
+
+   <t>
+    Both the Aggregation (A) label and the S-label have their MPLS S bit
+    set indicating bottom of stack, and the d-CW allows the PREF functions 
+    to work.
+   </t>
+   <t>
+    It is a property of the A-label that what follows is d-CW followed
+    by an S-label. A relay node processing the A-label would not know
+    the underlying payload type. This would only be known to a node
+    that was a peer of the node imposing the S-label. However there
+    is no real need for it to know the payload type during aggregation processing.
+   </t>
+  </section>
+
+ <section anchor="simple-aggregation-at-the-detnet-layer" title="Simple Aggregation at the DetNet layer">
+  <t>
+   Another approach would be not to include a d-CW for the aggregated flow.
+   This would be functionally similar to aggregation at the transport layer
+   using H-LSPs, but would confine knowledge of the aggregation to the 
+   DetNet layer. Such an approach shares the disadvantage that PREF 
+   operations would not be possible. OAM operation in this mode is 
+   for further study.
+  </t>
+
+<figure><artwork><![CDATA[
+ +---------------------------------+
+ |                                 |
+ |           DetNet Flow           |
+ |         Payload  Packet         |
+ |                                 |
+ +---------------------------------+ <--\
+ |       DetNet Control Word       |    |
+ +=================================+    |
+ |            S-Label              |    +----DetNet data plane    
+ +---------------------------------+    |    MPLS encapsulation
+ |            A-Label              |    |
+ +---------------------------------+ <--/
+ |           T-Label(s)            |
+ +---------------------------------+
+ |           Data-Link             |
+ +---------------------------------+
+ |           Physical              |
+ +---------------------------------+
+]]></artwork></figure>
+
+ </section>
+
+
+ <section title="Service layer considerations">
    <t>
     [Editor's note: quite a bit of unfinished and old text in the following sections.]
    </t>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -934,15 +934,6 @@ Placeholder
     within the DetNet domain. Thus the S-label can only be used to identify the DetNet flow
     at the intended receiving node.
    </t>
-   <t>
-    <list>
-     <t>
-      [Editor's note: We have specified the above for _data_ to leave the door open for the GAL
-      based OAM method as an alternative to the ACH mechanism currently specified.  When using GAL
-      the GAL label would be after the S-Label.  Do we leave this option in or shut the door on it?]
-     </t>
-    </list>
-   </t>
   </section>
 
   <section anchor="oam-indication" title="OAM Indication">
@@ -950,9 +941,6 @@ Placeholder
     OAM follows the procedures set out in <xref target="RFC5085"/> with the 
     restriction that only Virtual Circuit Connectivity Verification
     (VCCV) type 1 is supported.</t>
-
-   <t>Editor's Note - is this restriction acceptable? Do we need to
-      support GAL based OAM indication?</t>
 
    <t>As shown in Figure 3 of <xref target="RFC5085"/> when the first nibble of
     the d-CW is 0x0 the payload following the d-CW is normal user

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -26,6 +26,7 @@
 <!ENTITY rfc5462 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5462.xml">
 <!ENTITY rfc5586 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5586.xml">
 <!ENTITY rfc5659 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5659.xml">
+<!ENTITY rfc5085 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5085.xml">
 <!ENTITY rfc5921 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5921.xml">
 <!ENTITY rfc5960 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5960.xml">
 <!ENTITY rfc6073 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6073.xml">
@@ -881,7 +882,7 @@ Placeholder
 ]]>
     </artwork></figure>
   </section>
-  <section title="Flow identification">   
+  <section title="Flow Identification">   
    <t>
     DetNet flow identification at a DetNet service layer is realized by an S-label. It maps a Detnet
     flow to a specific d-CW in a DetNet node. For a data flow the S-label used for flow
@@ -903,7 +904,28 @@ Placeholder
     </list>
    </t>
   </section>
-  
+
+  <section anchor="oam-indication" title="OAM Indication">
+   <t>
+    OAM follows the procedures set out in <xref target="RFC5085"/> with the 
+    restriction that only Virtual Circuit Connectivity Verification
+    (VCCV) type 1 is supported.</t>
+
+   <t>Editor's Note - is this restriction acceptable? Do we need to
+      support GAL based OAM indication?</t>
+
+   <t>As shown in Figure 3 of <xref target="RFC5085"/> when the first nibble of
+    the d-CW is 0x0 the payload following the d-CW is normal user
+    data. However, when the first nibble of the d-CW is 0X1, the 
+    payload that follows the d-DW is an OAM payload with the OAM
+    type indicated by the value in the d-CW Channel Type field.</t>
+
+   <t>The reader is referred to <xref target="RFC5085"/> for a more detailed
+    description of the Associated Channel mechanism, and to the 
+    DetNet work on OAM for more information DetNet OAM.
+   </t>
+  </section>
+
    <section title="Service layer considerations">
    <t>
     [Editor's note: quite a bit of unfinished and old text in the following sections.]
@@ -1461,6 +1483,10 @@ Client AC   |             |           |             |
   </t>
 
  </section>
+
+<!-- ===================================================================== -->
+
+
 <!-- ===================================================================== -->
 
 <section title="Management and control considerations">
@@ -1670,6 +1696,7 @@ Client AC   |             |           |             |
    <?rfc include="reference.RFC.3473"?>
    <?rfc include="reference.RFC.4206"?>
    <?rfc include="reference.RFC.5129"?>
+   <?rfc include="reference.RFC.5085"?>
    <?rfc include="reference.RFC.5462"?>
    <?rfc include="reference.RFC.6003"?>
    &rfc6073;

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -120,7 +120,7 @@
  <section title="Introduction" anchor="sec_intro">
   <t>
     Deterministic Networking (DetNet) is a service that can be offered by a network to DetNet flows.
-    DetNet provides these flows extremely an low packet loss rates and assured maximum end-to-end
+    DetNet provides these flows extremely with an low packet loss rates and assured maximum end-to-end
     delivery latency.  General background and concepts of DetNet can be found in <xref
     target="I-D.ietf-detnet-architecture"/>.
   </t>
@@ -556,8 +556,8 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
   </t>
 
   <t>
-   As a general rule, DetNet domains MUST be capable to forward any Data-flows
-   and the DetNet domain MUST NOT intend to mandate end-system encapsulation
+   As a general rule, DetNet domains MUST be capable of forwarding any Data-flows
+   and the DetNet domain MUST NOT mandate the end-system encapsulation
    format. 
   </t>
 
@@ -599,7 +599,7 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
 
  <section title="DetNet domain specific considerations">
 
-  <t> From connection type perspective three scenarios are distinguished:
+  <t> From a connection type perspective, three scenarios are distinguished:
     <list style="numbers">
 	<t> Directly attached: end-system is directly connected to an edge node </t>
 	<t> Indirectly attached: end-system is behind a (L2-TSN / L3-DetNet) sub-net  </t>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -50,6 +50,7 @@
 <!ENTITY rfc7510 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7510.xml">
 
 <!ENTITY I-D.ietf-detnet-dp-alt PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-dp-alt.xml">
+<!ENTITY I-D.ietf-spring-segment-routing-mpls PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-spring-segment-routing-mpls">
 <!ENTITY I-D.ietf-detnet-problem-statement PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-problem-statement.xml">
 <!ENTITY I-D.ietf-detnet-architecture PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-architecture.xml">
 <!ENTITY I-D.ietf-mpls-residence-time SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-mpls-residence-time">
@@ -797,7 +798,7 @@ Placeholder
 
 <section title="MPLS-based DetNet data plane solution" anchor="dn-dt-solution">
 
- <section title="DetNet over MPLS Encapsulation Components">
+ <section title="DetNet over MPLS Encapsulation Components" anchor="dn-MPLS-en-comps">
   <!-- imported text from draft-bryant-detnet-mpls-dp-00.txt section "DetNet over MPLS Encapsulation
   Components" -->
   <t>
@@ -1321,7 +1322,117 @@ Client AC   |             |           |             |
     </section>
    </section>
  </section>
-  
+
+
+<section anchor="detnet-data-plane-encapsulation-for-ip-transport-networks" title="DetNet Data Plane Encapsulation for IP Transport Networks">
+ <t>
+  This section specifies the DetNet encapsulation over an IP transport network.
+  The approach is modeled on the operation of MPLS and PseudoWires (PW) over
+  an IP Packet Switched Network (PSN) <xref target="RFC3985"/><xref target="RFC4385"/><xref target="RFC7510"/>. 
+  It is also based on the MPLS data plane encapsulation described in <xref target="pwSolution"/>. 
+ </t>
+ <t>
+  To carry DetNet with full functionality at the DetNet layer over an IP transport network, the 
+  following components are required (these are a subset of the requirements for MPLS encapsulation 
+  listed in <xref target="dn-MPLS-en-comps"/>):
+  </t>
+  <t>
+   <list style="numbers">
+    <t>A method of identifying the DetNet flow group to the processing element.</t>
+    <t>A method of carrying the DetNet sequence number.</t>
+    <t>A method of distinguishing DetNet OAM packets from DetNet data packets.</t>
+    <t>A method of carrying queuing and forwarding indication.</t>
+   </list>
+  </t>
+ <t>
+  These requirements are satisfied by the DetNet over MPLS Encapsulation 
+  described in <xref target="pwSolution"/>. 
+ </t>
+ <t>
+  To simplify operations and implementations, rather than inventing a brand new 
+  encapsulation, the IP encapsulation takes advantage of the MPLS encapsulation. 
+  By using the specification of MPLS over UDP and IP in <xref target="RFC7510"/>, 
+  the T-Label(s) shown in <xref target="fig_pw_mpls"/> in <xref target="pwSolution"/> 
+  can be replaced by UDP and IP, resulting in the following encapsulation:
+ </t>
+
+ <figure title="IP Encapsulation of DetNet" anchor="IP-encap-dn">
+ <artwork align="center"><![CDATA[
++---------------------------------+
+|                                 |
+|           DetNet Flow           |
+|         Payload  Packet         |
+|                                 |
++---------------------------------+ <--\
+|       DetNet Control Word       |    |
++---------------------------------+    +--> DetNet data plane
+|             S-Label             |    |    MPLS encapsulation
++---------------------------------+ <--/
+|           UDP Header            |
++---------------------------------+
+|           IP Header             |
++---------------------------------+
+|           Data-Link             |
++---------------------------------+
+|           Physical              |
++---------------------------------+
+]]>
+ </artwork></figure>
+ <t>
+  Where the UDP header is used as defined in Section 3 of <xref target="RFC7510"/>.
+ </t>
+
+ <t>
+  As in <xref target="pwSolution"/>, the S-Label is used to identify a DetNet flow 
+  to the peer node that processes it, in this case the node addressed by the 
+  IP Header in <xref target="IP-encap-dn"/>. The S-Label is allocated from the receiving node?s 
+  platform label space <xref target="RFC3031"/>.
+ </t>
+ <t>
+  In ingress Edge Nodes, the encapsulation in <xref target="IP-encap-dn"/> will be imposed on 
+  Detnet Flow Payload Packets as received from DetNet End Systems, and the encapsulation 
+  will be removed in egress Edge Nodes as they transmit the Payload Packets to the End Systems.
+ </t>
+ <t>
+  Note that this encapsulation works equally well with IPv4 and IPv6.
+ </t>
+ <t>
+  This encapsulation can also be used in conjunction with segment routing as 
+  specified in <xref target="I-D.ietf-spring-segment-routing-mpls"/>. In this 
+  case, the T-Label(s) in <xref target="IP-encap-dn"/> should be retained, 
+  and at each hop, the top T-label is popped and mapped to a corresponding 
+  UDP/IP tunnel, resulting in the following encapsulation:
+ </t>
+
+ <figure title="IP Encapsulation of DetNet with MPLS-SR" anchor="IP-encap-dn-sr">
+ <artwork align="center"><![CDATA[
+  +---------------------------------+
+  |                                 |
+  |           DetNet Flow           |
+  |         Payload  Packet         |
+  |                                 |
+  +---------------------------------+ <--\
+  |       DetNet Control Word       |    |
+  +---------------------------------+    +--> DetNet data plane
+  |           S-Label               |    |    MPLS encapsulation
+  +---------------------------------+ <--/
+  |           T-Label(s)            |
+  +---------------------------------+
+  |           UDP Header            |
+  +---------------------------------+
+  |           IP Header             |
+  +---------------------------------+
+  |           Data-Link             |
+  +---------------------------------+
+  |           Physical              |
+  +---------------------------------+
+]]>
+ </artwork></figure>
+ <t>
+  Again, the UDP header is used as defined in Section 3 of <xref target="RFC7510"/>.
+ </t>
+</section>
+
 <section title="Other DetNet data plane considerations">
   <t> NOTE: these sections are simple copy pasted from earlier document. 
   They may not be needed.  
@@ -1884,6 +1995,7 @@ Client AC   |             |           |             |
    &rfc4385;
    &rfc4023;
    &rfc7510;
+   &I-D.ietf-spring-segment-routing-mpls;
    <?rfc include="reference.RFC.8200"?>
   </references>
   <references title="Informative references">

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -936,6 +936,41 @@ Placeholder
     at the intended receiving node.
    </t>
   </section>
+ 
+  <section title="Indication of the DetNet Payload Type" anchor="PTI-section">
+   <t>
+    The only nodes that needs to know the payload type of a flow are the
+    DetNet ingress node and the DetNet egress nodes.
+    The ingress node has to know how to process the packet it receives
+    from the ingress AC, and egress edge node has to know how to
+    prepare the packet for transmission on the egress AC.
+   </t>
+   <t>
+    On ingress a DetNet edge node has to classify the packets into those
+    that are for transmission as Detnet packets and those that are for
+    transmission as "normal" packets at one of more lower priorities.
+    The packet type is indicated to the egress edge node through the
+    value of the S-label.  Thus, when the egress edge node looks up the
+    S-label one of the parameters returned is the packet type which in
+    turn tells the egress edge node how to prepare the packet for
+    transmission over the egress AC.
+   </t>
+   <t>
+    The consequence of this approach is that if multiple packet encapsulations
+    are processed on a node, each will need its own S-Label. That is not
+    generally a problems, since it is anticipated that only one encapsulation 
+    type intented for carriage as a DetNet flow will be present on any egress.
+    However, IPv4 and IPv6 have different forwarding equivalence classes (FEC)
+    in MPLS and are therefore allocated different labels rather than being distinguished
+    through the IP version field in the IP header. Futhermore IPv4 and IPv6
+    when running directly over Ethernet are identified via the Ethertype rather 
+    than via the IP version number. Whilst it ought to be safe to identify 
+    the IP type though the IP version number the absence this approach in
+    practical applications suggests that it is more conservative to distinguish
+    between IP types through the S-Label. Thus when the payload is IP, two
+    S-Labels are used, one to identify an IPv4 payload and one to identify an IPv6 payload.
+   </t>
+  </section>
 
   <section anchor="oam-indication" title="OAM Indication">
    <t>
@@ -1110,6 +1145,10 @@ Placeholder
  <section title="Service layer considerations">
    <t>
     [Editor's note: quite a bit of unfinished and old text in the following sections.]
+   </t>
+   <t></t>
+   <t>
+    [Editor's note: when this section is re-written a reference to <xref target="PTI-section"/> should be included]
    </t>
    <t>
      The edge and relay node internal procedures of the PROEF are implementation specific.  The order

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -179,13 +179,22 @@
         specific service function.
      </t>
 
-    <t hangText="PREF">
-     A Packet Replication and Elimination Function (PREF) does the replication
-     and elimination processing of DetNet flow packets in edge or relay
-     nodes. The replication function is essentially the existing 1+n protection
-     mechanism. The elimination function reuses and extends the existing duplicate 
-	 detection mechanism to operate over multiple (separate) DetNet member flows of a 
-	 DetNet compound flow.</t>
+    <t hangText="PEF">
+     A Packet Elimination Function (PEF) elimates duplicate copies of packets received
+     by an edge or a relay node to prevent excess packets flooding the network, or to
+     prevent duplicate packets being sent out of the DetNet domain.
+    </t>
+
+    <t hangText="PRF">
+     A Packet Replication Function (PRF) replicates DetNet flow packets in an edge or a relay
+     node and forwards them to one or more next hops in the DetNet domain. The number of packet copies sent 
+     to each next hop is a parameter of the DetNet flow at the node doing the replication.
+    </t>
+
+    <t hangText="PROF">
+     A Packet Reorder Function (PROF) re-orders packets within a DetNet flow  that are received out of order.
+     This function may be implemented at an edge or a relay node.
+    </t>
     
     <t hangText="DetNet Control Word">
 	  A control word used for sequencing and identifying duplicate packets at the DetNet service
@@ -213,6 +222,9 @@
     <t hangText="NSP">Native Service Processing.</t>
     <t hangText="OAM">Operations, Administration, and Maintenance.</t>
     <t hangText="PE">Provider Edge.</t>
+    <t hangText="PEF">Packet Elimination Function.</t>
+    <t hangText="PRF">Packet Replication Function.</t>
+    <t hangText="PROF">Packet Reorder Function.</t>
     <t hangText="PREF">Packet Replication and Elimination Function.</t>
     <t hangText="PSN">Packet Switched Network.</t>
     <t hangText="PW">PseudoWire.</t>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -120,7 +120,7 @@
  <section title="Introduction" anchor="sec_intro">
   <t>
     Deterministic Networking (DetNet) is a service that can be offered by a network to DetNet flows.
-    DetNet provides these flows extremely low packet loss rates and assured maximum end-to-end
+    DetNet provides these flows extremely an low packet loss rates and assured maximum end-to-end
     delivery latency.  General background and concepts of DetNet can be found in <xref
     target="I-D.ietf-detnet-architecture"/>.
   </t>
@@ -166,9 +166,18 @@
     also used to identify a DetNet flow at DetNet service layer.</t>
 	
     <t hangText="Local-ID">
-     A DetNet Edge and Relay node internal construct that uniquely identifies a DetNet flow within a
-     node and never appear on-wire. It may be used to select proper forwarding and/or DetNet
-     specific service function.</t>
+
+        [Note to the editors this section is not needed. This is internal to the node. With
+        pseudowires we needed global identifier for the control plane to identfy the PW to
+        the node, and we used platform label space to ensure the PW was identiable when
+        it was received. I think this can be deleted - SB]
+     </t>
+
+     <t>
+        A DetNet Edge and Relay node internal construct that uniquely identifies a DetNet flow within a
+        node and never appear on-wire. It may be used to select proper forwarding and/or DetNet
+        specific service function.
+     </t>
 
     <t hangText="PREF">
      A Packet Replication and Elimination Function (PREF) does the replication
@@ -179,7 +188,7 @@
 	 DetNet compound flow.</t>
     
     <t hangText="DetNet Control Word">
-	  A control word used for sequencing and identifying duplaicate packets at the DetNet service
+	  A control word used for sequencing and identifying duplicate packets at the DetNet service
       layer. </t> 
     </list>
    </t>
@@ -421,6 +430,10 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
   ensuring congestion protection and latency control for the above listed DetNet functions.
  </t>
  <t>
+  [Note to Editors. I am not convinced that the previous para adds value. It certainly has
+  the opportunity to add confusion. I think it needs to be deleted - SB] 
+ </t>
+ <t>
   The DetNet data plane allows for the aggregation of DetNet flows, e.g., via MPLS hierarchical
   LSPs, to improved scaling.  When DetNet flows are aggregated, transit nodes may have limited
   ability to provide service on per-flow DetNet identifiers. Therefore, identifying each individual
@@ -442,6 +455,9 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
   On each DetNet node dealing with DetNet flows, an internal local-ID is assumed to determine what
   local operation a packet goes through. Therefore, local-IDs has to be unique on each edge and
   relay nodes. Local-ID is unambiguously bound to the DetNet flow. 
+ </t>
+ <t>
+   [Note to Editor - again I think previous para needs to be removed]
  </t>
  </section>
 
@@ -466,6 +482,9 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
    local-ID if they belong to the same DetNet (compound) flow and share the same sequence number
    counter and the history information. The location of the packet elimination on the packet
    processing pipeline is implementation specific.
+  </t>
+  <t>
+   [Note to editor - Clean up local-id when dealing with PREF text] 
   </t>
  </section>
  <section title="Packet reordering considerations">
@@ -809,7 +828,7 @@ Placeholder
       space for each DetNet flow.</t>
      <t>
       DetNet service Label (S-label) that identifies a DetNet flow to the peer node that is to process it.
-      The S-Label is allocated from the platform label space.
+      The S-Label is allocated from the platform label space <xref target="RFC3031"/>.
 	  </t>
      <!-- t>
       An optional DetNet service label (S2-Label) that represents DetNet Service LSP used between
@@ -884,15 +903,19 @@ Placeholder
   </section>
   <section title="Flow Identification">   
    <t>
-    DetNet flow identification at a DetNet service layer is realized by an S-label. It maps a Detnet
-    flow to a specific d-CW in a DetNet node. For a data flow the S-label used for flow
-    identification MUST be bottom label of the label stack for a DetNet-s- or DetNet-st-flow and
+    DetNet flow identification at a DetNet service layer is realized by an S-label. 
+    The S-lable is allocated from the platform label label space <xref target="RFC3031"/>
+    Thich means that the DetNet flow is correctly identified and matched to the 
+    flow parameters, including the flow history, regardless of which input interface 
+    the packet arrives on.
+    The S-label MUST be at the bottom label of the label stack for a DetNet-s- or DetNet-st-flow and
     MUST precede the d-CW. 
    </t>
    <t>
-    An S-label for a single DetNet flow does not need to be unique DetNet domain wide. As long
-    as two or more different DetNet flows do not errorneously map to a same d-CW in a DetNet node
-    the labels may vary. 
+    The S-label for a specific DetNet flow is unique to that DetNet flow on a specific node, but
+    is not required to be identical with the S-lable for that DetNet flow in any other node
+    within the DetNet domain. Thus the S-label can only be used to identify the DetNet flow
+    at the intended receiving node.
    </t>
    <t>
     <list>
@@ -1814,6 +1837,7 @@ Client AC   |             |           |             |
    <?rfc include="reference.RFC.2212"?>
    <?rfc include="reference.RFC.2474"?>
    <?rfc include="reference.RFC.3168"?>
+   <?rfc include="reference.RFC.3031"?>
    <?rfc include="reference.RFC.3032"?>
    <?rfc include="reference.RFC.3209"?>
    <?rfc include="reference.RFC.3270"?>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -968,13 +968,6 @@ Placeholder
 
   <section anchor="FAG" title="Flow Aggregation">
    <t>
-    The ability to aggregate individual flows, and their associated
-    resource control, into a larger aggregate is an important technique
-    for improving scaling of control in the data, management and control
-    planes.  The DetNet data plane allows for the aggregation of DetNet flows,
-    to improved scaling. There are three methods of introducing flow aggregation:
-   </t>
-   <t>
     <list style="numbers">
      <t>Aggregate at the LSP (Transport)</t>
      <t>Aggregating DetNet flows as a new DetNet flow</t>
@@ -989,36 +982,70 @@ Placeholder
     management aspects of aggregation (including the queuing/shaping/
     policing implications) will be covered in other documents.
    </t>
-  </section>
-  <section anchor="aggregation-at-the-lsp" title="Aggregation at the LSP">
    <t>
-    DetNet flows transported via MPLS can leverage MPLS-TE?s existing
-    support for hierarchical LSPs (H-LSPs), see <xref target="RFC4206"/>.  H-LSPs are
-    typically used to aggregate control and resources, they may also be
-    used to provide OAM or protection for the aggregated LSPs.  Arbitrary
-    levels of aggregation naturally falls out of the definition for
-    hierarchy and the MPLS label stack <xref target="RFC3032"/>.  DetNet nodes which
-    support aggregation (LSP hierarchy) map one or more LSPs (labels)
-    into and from an H-LSP.  Both carried LSPs and H-LSPs may or may not
-    use the TC field, i.e., L-LSPs or E-LSPs.  Such nodes will need to
-    ensure that traffic from aggregated LSPs are placed (shaped/policed/
-    enqueued) onto the H-LSPs in a fashion that ensures the required
-    DetNet service is preserved.
+    The ability to aggregate individual flows, and their associated
+    resource control, into a larger aggregate is an important technique
+    for improving scaling of control in the data, management and control
+    planes.  The DetNet data plane allows for the aggregation of DetNet flows,
+    to improved scaling. There are three methods of introducing flow aggregation:
+   </t>
+   <t> 
+    The following review comments were received when this section
+    was committed to github.
    </t>
    <t>
-    Additional details of the traffic
-    control capabilities needed at a DetNet-aware node may be covered in
-    the new service descriptions mentioned above or in separate future
-    documents.  Management and control plane mechanisms will also need to
-    ensure that the service required on the aggregate flow (H-LSP or
-    DSCP) are provided, which may include the discarding or remarking
-    mentioned in the previous sections.
+    General comment: We should points to the major issue of aggregation, 
+    namely the Seq.Num related problem. The aggregated flows have their 
+    own Seq.Num and those are independent. We should consider to 
+    group the aggregation techniques as per their impact on what DetNet 
+    functions they allow on a DetNet flow. (E.g., aggregation without 
+    new Aggregate.Seq.Num would prohibit usage of FR, EF and IoD 
+    function on the aggregate flow).
    </t>
-  </section>
-  <section anchor="aggregating-detnet-flows-as-a-new-detnet-flow" title="Aggregating DetNet flows as a new DetNet flow">
    <t>
-    An aggregate can be built by layering DetNet flows as shown below:
+    SR based aggregation can be treated as a form of H-LSP aggregation. 
+    Should we differentiate them? What are the differences?
    </t>
+   <t>
+    What are the issues when aggregating of different payload types? Should we 
+    add an editor note on this?
+   </t>
+   <t>
+    Simple-aggregation-at-the-detnet-layer: is this not the same as H-LSP? 
+    The A-label can be treated just as an additional T-label.
+   </t>
+   <t>
+    End of review comment.
+   </t>
+   <section anchor="aggregation-at-the-lsp" title="Aggregation at the LSP">
+    <t>
+     DetNet flows transported via MPLS can leverage MPLS-TE?s existing
+     support for hierarchical LSPs (H-LSPs), see <xref target="RFC4206"/>.  H-LSPs are
+     typically used to aggregate control and resources, they may also be
+     used to provide OAM or protection for the aggregated LSPs.  Arbitrary
+     levels of aggregation naturally falls out of the definition for
+     hierarchy and the MPLS label stack <xref target="RFC3032"/>.  DetNet nodes which
+     support aggregation (LSP hierarchy) map one or more LSPs (labels)
+     into and from an H-LSP.  Both carried LSPs and H-LSPs may or may not
+     use the TC field, i.e., L-LSPs or E-LSPs.  Such nodes will need to
+     ensure that traffic from aggregated LSPs are placed (shaped/policed/
+     enqueued) onto the H-LSPs in a fashion that ensures the required
+     DetNet service is preserved.
+    </t>
+    <t>
+     Additional details of the traffic
+     control capabilities needed at a DetNet-aware node may be covered in
+     the new service descriptions mentioned above or in separate future
+     documents.  Management and control plane mechanisms will also need to
+     ensure that the service required on the aggregate flow (H-LSP or
+     DSCP) are provided, which may include the discarding or remarking
+     mentioned in the previous sections.
+    </t>
+    </section>
+    <section anchor="aggregating-detnet-flows-as-a-new-detnet-flow" title="Aggregating DetNet flows as a new DetNet flow">
+    <t>
+     An aggregate can be built by layering DetNet flows as shown below:
+    </t>
 
 <figure><artwork><![CDATA[
 +---------------------------------+
@@ -1043,31 +1070,31 @@ Placeholder
 +---------------------------------+
 ]]></artwork></figure>
 
-   <t>
-    Both the Aggregation (A) label and the S-label have their MPLS S bit
-    set indicating bottom of stack, and the d-CW allows the PROEF
-    to work.
-   </t>
-   <t>
-    It is a property of the A-label that what follows is d-CW followed
-    by an S-label. A relay node processing the A-label would not know
-    the underlying payload type. This would only be known to a node
-    that was a peer of the node imposing the S-label. However there
-    is no real need for it to know the payload type during aggregation processing.
-   </t>
-  </section>
+    <t>
+     Both the Aggregation (A) label and the S-label have their MPLS S bit
+     set indicating bottom of stack, and the d-CW allows the PROEF
+     to work.
+    </t>
+    <t>
+     It is a property of the A-label that what follows is d-CW followed
+     by an S-label. A relay node processing the A-label would not know
+     the underlying payload type. This would only be known to a node
+     that was a peer of the node imposing the S-label. However there
+     is no real need for it to know the payload type during aggregation processing.
+    </t>
+   </section>
 
- <section anchor="simple-aggregation-at-the-detnet-layer" title="Simple Aggregation at the DetNet layer">
-  <t>
-   Another approach would be not to include a d-CW for the aggregated flow.
-   This would be functionally similar to aggregation at the transport layer
-   using H-LSPs, but would confine knowledge of the aggregation to the 
-   DetNet layer. Such an approach shares the disadvantage that PROEF
-   operations would not be possible. OAM operation in this mode is 
-   for further study.
-  </t>
+   <section anchor="simple-aggregation-at-the-detnet-layer" title="Simple Aggregation at the DetNet layer">
+    <t>
+    Another approach would be not to include a d-CW for the aggregated flow.
+    This would be functionally similar to aggregation at the transport layer
+    using H-LSPs, but would confine knowledge of the aggregation to the 
+    DetNet layer. Such an approach shares the disadvantage that PROEF
+    operations would not be possible. OAM operation in this mode is 
+    for further study.
+   </t>
 
-<figure><artwork><![CDATA[
+   <figure><artwork><![CDATA[
  +---------------------------------+
  |                                 |
  |           DetNet Flow           |
@@ -1088,8 +1115,8 @@ Placeholder
  +---------------------------------+
 ]]></artwork></figure>
 
+  </section>
  </section>
-
 
  <section title="Service layer considerations">
    <t>

--- a/draft-ietf-detnet-dp-sol-mpls-00.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-00.xml
@@ -135,9 +135,9 @@
     is assumed to be in place in a DetNet node.
   </t>
   <t>
-   Furthermore, this document also describes how DetNet flows are identified, how a DetNet
-   Relay/Edge/Transit nodes work, and how the Packet Replication and Elimination function (PREF) is
-   implemented with the two data plane solutions.
+   Furthermore, this document also describes how DetNet flows are identified, and how a DetNet
+   Relay/Edge/Transit nodes works. It also describes the function and operation of the Packet Replication (PRF)
+   Packet Elimination (PEF) and Packet Reordering (PROF) functions in the MPLS data plane.
   </t>
   <t>
    This document does not define the associated control plane functions, or Operations,
@@ -165,20 +165,6 @@
     nodes that implment also the DetNet service layer functions. An S-Label is
     also used to identify a DetNet flow at DetNet service layer.</t>
 	
-    <t hangText="Local-ID">
-
-        [Note to the editors this section is not needed. This is internal to the node. With
-        pseudowires we needed global identifier for the control plane to identfy the PW to
-        the node, and we used platform label space to ensure the PW was identiable when
-        it was received. I think this can be deleted - SB]
-     </t>
-
-     <t>
-        A DetNet Edge and Relay node internal construct that uniquely identifies a DetNet flow within a
-        node and never appear on-wire. It may be used to select proper forwarding and/or DetNet
-        specific service function.
-     </t>
-
     <t hangText="PEF">
      A Packet Elimination Function (PEF) elimates duplicate copies of packets received
      by an edge or a relay node to prevent excess packets flooding the network, or to
@@ -189,6 +175,10 @@
      A Packet Replication Function (PRF) replicates DetNet flow packets in an edge or a relay
      node and forwards them to one or more next hops in the DetNet domain. The number of packet copies sent 
      to each next hop is a parameter of the DetNet flow at the node doing the replication.
+    </t>
+
+    <t hangText="PROEF">
+     Collective name for Packet Replication, Re-order and Elimination Functions.
     </t>
 
     <t hangText="PROF">
@@ -224,8 +214,8 @@
     <t hangText="PE">Provider Edge.</t>
     <t hangText="PEF">Packet Elimination Function.</t>
     <t hangText="PRF">Packet Replication Function.</t>
+    <t hangText="PROEF">Packet Replication, Reodering and Elimination Functions.</t>
     <t hangText="PROF">Packet Reorder Function.</t>
-    <t hangText="PREF">Packet Replication and Elimination Function.</t>
     <t hangText="PSN">Packet Switched Network.</t>
     <t hangText="PW">PseudoWire.</t>
     <t hangText="QoS">Quality of Service.</t>
@@ -473,39 +463,54 @@ CE1----EN1--------R1-------R2-------R3--------EN2----CE2
  </t>
  </section>
 
- <section title="Packet replication and elimination considerations">
+ <section title="Packet Replication and Elimination Considerations">
   <t>
-   DetNet service layer introduces packet replication and elimination functionality (PREF) for use
-   in DetNet edge and relay node and end system packet processing.  PREF MAY be enabled in a DetNet
-   node and the required processing is only applied to packets with  a positive flow identification
-   at the DetNet service layer. PREF utilizes a sequence number carried within a DetNet flow
-   packets.
+   DetNet service layer introduces packet replication (PRF) and packet elimination functionality (PEF) for use
+   in DetNet edge and relay node and end system packet processing.  Either or both of these functions MAY 
+   be enabled in a DetNet
+   node. The required processing is applied to packets that are identified by the S-Label
+   as requiring one or both of these functions to be applied. Ingress packets may be identified as
+   requiring replication as part of the input processing mechanism that applies the encapsulation
+   to the packet. The 
+   PRF and PEF utilizes a sequence number that is carried within the DetNet flow packet.
   </t>
   <t>
-   At a DetNet node level the output of the PREF elimination function is always a single packet.
-   The output of the PREF replication function at a DetNet node level is always one or more packets
-   (i.e., 1:M replication). The replicated packets MUST share the same d-CW i.e., the sequence
-   number is the same for each member flow of the compound flow. The location and mechanism on the
-   packet processing pipeline used for replication is implementation specific.
+   The order in which a node applies the PEF and the PRF to a DetNet flow is implimentation 
+   specific.
   </t>
   <t>
-   The complex part of the DetNet PREF processing is tracking the history of received packets for
-   multiple DetNet member flows. These ingress DetNet member flows (to a node) MUST have the same
-   local-ID if they belong to the same DetNet (compound) flow and share the same sequence number
-   counter and the history information. The location of the packet elimination on the packet
-   processing pipeline is implementation specific.
+   The output of the PRF is always one or more packets
+   (i.e., 1:M replication). Packets output from the PRF MUST include the same d-CW as the 
+   as the input packet. This ensures that the sequence
+   number is the same for each member flow of the compound flow. 
+   The location within a node, and the mechanism used for the PRF is implementation specific.
   </t>
   <t>
-   [Note to editor - Clean up local-id when dealing with PREF text] 
+   The output of the PEF is always a single packet.
+   A DetNet PEF must track the history of received packets for each 
+   DetNet flow that it is configured to process. Packet for a particular DetNet flow 
+   to be processed by the PEF MUST share the same S-Label, sequence number counter 
+   and history information. The location within a node, and mechanism used for the 
+   PEF is implementation specific.
   </t>
- </section>
+  </section>
  <section title="Packet reordering considerations">
   <t>     
-   DetNet service layer introduces also packet reordering functionality for use in DetNet edge and
-   relay node and end system packet processing. The reordering functionality MAY be enabled in a
-   DetNet node. The reordeing functionality relies on a presence of sequence numbers in a DetNet
-   (compound) flows. The reordering processing is only applied to packets with  a positive flow
-   identification at the DetNet service layer.
+   DetNet service layer introduces packet reordering functionality (PROF) for use in DetNet edge and
+   relay node and end system packet processing. The PROF MAY be enabled in a
+   DetNet node. The PROF relies on the  presence of sequence numbers in a DetNet
+   (compound) flows. The PROF is only applied to DetNet flows that are identified
+   by the S-Label as requiring this function. 
+  </t>
+  <t>
+   Editors note: I cannot remember what we concluded about the following. We can remove
+   it is a future version if we decide it is too complicated or not needed.
+  </t>
+  <t>
+   A DetNet Flow MAY use the sequence number as a proxy for a timestamp. In such cases
+   packets that are delayed by more than the time specified for that DetNet flow
+   are discarded. Detailed technical considerations of this processing are for 
+   further study.
   </t>
  </section>
 </section>  <!-- end of data plane overview -->
@@ -1040,7 +1045,7 @@ Placeholder
 
    <t>
     Both the Aggregation (A) label and the S-label have their MPLS S bit
-    set indicating bottom of stack, and the d-CW allows the PREF functions 
+    set indicating bottom of stack, and the d-CW allows the PROEF
     to work.
    </t>
    <t>
@@ -1057,7 +1062,7 @@ Placeholder
    Another approach would be not to include a d-CW for the aggregated flow.
    This would be functionally similar to aggregation at the transport layer
    using H-LSPs, but would confine knowledge of the aggregation to the 
-   DetNet layer. Such an approach shares the disadvantage that PREF 
+   DetNet layer. Such an approach shares the disadvantage that PROEF
    operations would not be possible. OAM operation in this mode is 
    for further study.
   </t>
@@ -1091,7 +1096,7 @@ Placeholder
     [Editor's note: quite a bit of unfinished and old text in the following sections.]
    </t>
    <t>
-     The edge and relay node internal procedures of the PREF are implementation specific.  The order
+     The edge and relay node internal procedures of the PROEF are implementation specific.  The order
      of a packet elimination or replication is out of scope in this specification. However, care
      should be taken that the replication function does not actually loopback packets as "replicas".
      Looped back packets include artificial delay when the node that originally initiated the packet
@@ -1168,7 +1173,7 @@ Client AC   |             |           |             |
 	   </t>
 	   <t hangText="Discussion:">
 		   When it comes to use of NSPs, agree. Also for "island interconnect" this is
-		   a fine. However, when there is a need to do PREF in a middle, plain edge to edge
+		   a fine. However, when there is a need to do PROEF in a middle, plain edge to edge
 		   is not enough.
   	 </t>
 	</list>
@@ -1208,15 +1213,15 @@ Client AC   |             |           |             |
      elimination. This processing is done within an extended forwarder function.
      Whether an ingress DetNet member flow receives DetNet specific processing depends on how
      the forwarding is programmed.  For some DetNet member flows the relay node can act as a normal relay node
-     and for some apply the DetNet specific processing (i.e., PREF).
+     and for some apply the DetNet specific processing (i.e., PROEF).
     <list style="hanging">
 	   <t hangText="Comment #7">
            SB> Again relay node is not a normal term, so am not sure what it does
-            in the absence of a PREF function.
+            in the absence of a PROEF function.
            </t>
 	   <t hangText="Discussion:">
 		   Relay node was a DetNet aware S-PE originally, which is not explicitly stated here anymore, thus
-                   slightly confusing text here. The text here needs to clarify the roles of PREF and switching
+                   slightly confusing text here. The text here needs to clarify the roles of PROEF and switching
 		   functions. A DetNet relay is described in the architecture document. However, there is definitely
 		   room for termonilogy and text improvements.
   	 </t>
@@ -1507,9 +1512,9 @@ Client AC   |             |           |             |
 
  <!-- section title="Packet replication and elimination function">
      <t>
-         [editor's note: collect details of the PREF here. Potential topics to discuss relate to
+         [editor's note: collect details of the PROEF here. Potential topics to discuss relate to
          constraints to input packets and what the expected output is. Some examples include: the
-         input packets must have the same PW Label (in a case of PWs) to enable the PREF, no
+         input packets must have the same PW Label (in a case of PWs) to enable the PROEF, no
          loopback for replicated packets, input and output PW labels do not need to be the same.
          Also, add text regarding native IPv6 encapsulation. There the PW label is replaced with
          source address + flow label combination, and the Control Word is replaced with the DetNet
@@ -1667,7 +1672,7 @@ Client AC   |             |           |             |
   <t>
    [Editor's note: This section is a work in progress.
    discuss here what kind of enhancements are needed for DetNet
-   and specifically for PREF and DetNet zero congest loss and latency
+   and specifically for PROEF and DetNet zero congest loss and latency
    control. Need to cover both traffic control (queuing) and connection
    control (control plane).]
  </t>
@@ -1718,7 +1723,7 @@ Client AC   |             |           |             |
    [Editor's note: Outdated and at the functional level technology independent.. but needs more work.]		 
   </t>
   <t>
-   The control plane protocol solution required for managing the PREF processing
+   The control plane protocol solution required for managing the PROEF processing
    is outside the scope of this document.
   </t>
  </section>
@@ -1930,7 +1935,7 @@ Client AC   |             |           |             |
  <section title="Example of DetNet data plane operation" anchor="sec_comb">
   <t>
    [Editor's note: Add a simplified example of DetNet data plane and how labels etc
-   work in the case of MPLS-based PSN and utilizing PREF. The figure is subject
+   work in the case of MPLS-based PSN and utilizing PROEF. The figure is subject
    to change depending on the further DT decisions on the label handling..]
   </t>
  </section>


### PR DESCRIPTION
Put the text that was taken out of the payload ident section back in.

Fixed some compile warnings

Two were figs too large

One was use of [IEEE1588] instead of <xref....>

Rest were apparently unused references

Requesting pull so we are in sync on this.