### PR TITLE
Reorg to remove applications (IP over MPLS) from doc

### DIFF
--- a/draft-ietf-detnet-dp-sol-mpls-02.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-02.xml
@@ -174,7 +174,7 @@
  </section>
 
  <section title="Terminology">
-  <section title="Terms used in this document">
+  <section title="Terms Used in This Document">
   <t>
    This document uses the terminology established in the DetNet architecture
    <xref target="I-D.ietf-detnet-architecture"/>, and the reader is assumed
@@ -236,7 +236,7 @@
   </section>
  </section>  <!-- end of terminology -->
 
- <section title="Requirements language">
+ <section title="Requirements Language">
   <t>
     The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
     "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
@@ -246,8 +246,8 @@
   </t>
  </section>
 
- <section title="MPLS DetNet data plane overview" anchor="sec_dt_dp">
-  <section title="Layers of DetNet data plane" anchor="sec_lay_dt_dp">
+ <section title="MPLS DetNet Data Plane Overview" anchor="sec_dt_dp">
+  <section title="Layers of DetNet Data Plane" anchor="sec_lay_dt_dp">
   <t>
     This document describes how DetNet flows are carried over MPLS
     networks. The DetNet Architecture, <xref
@@ -262,7 +262,7 @@
     found in <xref target="RFC3272"/> and <xref target="RFC3209"/>.
   </t>
   <figure anchor="dn_mpls_dp_approach" align="center"
-          title="DetNet adaptation to MPLS data plane">
+          title="DetNet Adaptation to MPLS Data Plane">
     <artwork align="center"><![CDATA[
   DetNet        MPLS
     .
@@ -486,7 +486,7 @@ End System        Node         Node           Node        End System
       </t>
 
       <figure align="center" anchor="fig_ip_pw_detnet"
-              title="DetNet IP over DetNet MPLS Network">
+              title="DetNet IP Over DetNet MPLS Network">
         <artwork><![CDATA[
       DetNet                                         DetNet
 IP    Service         Transit          Transit       Service  IP
@@ -514,7 +514,7 @@ System  |   +--------+       +--------+       +--------+   |  System
       </figure>
 
       <figure align="center" anchor="fig_ip_mpls_detnet"
-              title="Non-DetNet aware IP Over DetNet MPLS Network">
+              title="Non-DetNet Aware IP Over DetNet MPLS Network">
         <artwork><![CDATA[
  IP               Edge                        Edge        IP
  End System       Node                        Node        End System
@@ -640,7 +640,7 @@ title="A TSN over DetNet MPLS Enabled Network">
   </t>
 
   <figure align="center" anchor="fig_8021_detnet"
-  title="IEEE 802.1TSN over DetNet">
+  title="IEEE 802.1TSN Over DetNet">
   <artwork><![CDATA[
      TSN    |<------- End to End DetNet Service ------>|  TSN
     Service |         Transit          Transit         | Service
@@ -668,7 +668,7 @@ System |    +--------+       +--------+       +--------+   |  System
   </section>
   </section>
 
-  <section title="Packet flow example (service protection)">
+  <section title="Packet Flow Example with Service Protection">
 
  <t>
    An example MPLS DetNet network fragment and packet flow is
@@ -676,7 +676,7 @@ System |    +--------+       +--------+       +--------+   |  System
  </t>
 
  <figure align="center" anchor="fig_mpls_example"
-  title="Example Packet flow in DetNet Enabled MPLS Network">
+  title="Example Packet Flow in DetNet Enabled MPLS Network">
  <artwork><![CDATA[
    1      1.1       1.1      1.2.1    1.2.1      1.2.2
 CE1----EN1--------R1-------R2-------R3--------EN2-----CE2
@@ -824,7 +824,7 @@ CE1----EN1--------R1-------R2-------R3--------EN2-----CE2
    L2VPN applications.
   </t>
 
-  <figure title="End-Systems and the DetNet MPLS Domain" anchor="fig_es_connect">
+  <figure title="End-Systems and The DetNet MPLS Domain" anchor="fig_es_connect">
   <artwork align="center"><![CDATA[
 +-----+
 |  X  |                               +-----+
@@ -893,9 +893,9 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
 
 <!-- ================================================================= -->
 
-<section title="MPLS-based DetNet data plane solution" anchor="dn-dt-solution">
+<section title="MPLS-Based DetNet Data Plane Solution" anchor="dn-dt-solution">
 
- <section title="DetNet over MPLS Encapsulation Components" anchor="dn-MPLS-en-comps">
+ <section title="DetNet Over MPLS Encapsulation Components" anchor="dn-MPLS-en-comps">
   <t>
    To carry DetNet over MPLS the following is required:
 
@@ -945,7 +945,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
   </t>
  </section>
 
-  <section title="MPLS data plane encapsulation" anchor="pwSolution">
+  <section title="MPLS Data Plane Encapsulation" anchor="pwSolution">
    <t>
     <xref target="fig_pw_mpls"/> illustrates a DetNet data plane MPLS encapsulation.  The MPLS-based
     encapsulation of the DetNet flows is a good fit for the Layer-2 interconnect deployment cases
@@ -976,7 +976,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     </list>
    </t>
 
-  <figure title="Encapsulation of a DetNet flow in an MPLS(-TP) PSN" anchor="fig_pw_mpls">
+  <figure title="Encapsulation of a DetNet Flow in an MPLS(-TP) PSN" anchor="fig_pw_mpls">
   <artwork align="center"><![CDATA[
   DetNet MPLS-based encapsulation
 
@@ -1000,7 +1000,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     </artwork></figure>
 
   </section>
-  <section title="DetNet control word">
+  <section title="DetNet Control Word">
   <t>
    A DetNet control word (d-CW) conforms to the Generic PW MPLS Control Word (PWMCW) defined in
    <xref target="RFC4385"/> and is illustrated in  <xref target="fig_detnet_cw"/>.  The upper nibble
@@ -1187,7 +1187,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
      mentioned in the previous sections.
     </t>
     </section>
-    <section anchor="aggregating-detnet-flows-as-a-new-detnet-flow" title="Aggregating DetNet flows as a new DetNet flow">
+    <section anchor="aggregating-detnet-flows-as-a-new-detnet-flow" title="Aggregating DetNet Flows as a new DetNet flow">
     <t>
      An aggregate can be built by layering DetNet flows as shown below:
     </t>
@@ -1229,7 +1229,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     </t>
    </section>
 
-   <section anchor="simple-aggregation-at-the-detnet-layer" title="Simple Aggregation at the DetNet layer">
+   <section anchor="simple-aggregation-at-the-detnet-layer" title="Simple Aggregation at the DetNet Layer">
     <t>
     Another approach would be not to include a d-CW for the aggregated flow.
     This would be functionally similar to aggregation at the forwarding sub-layer
@@ -1285,7 +1285,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     would be severe.
    </t>
 
-   <section title="Edge node processing" anchor="sec_t_pe">
+   <section title="Edge Node Processing" anchor="sec_t_pe">
     <t>
      An edge node is resposable for matching ingress packets to the service they require and
      encapsulating them accordingly.An edge node may participate in the packet replication and
@@ -1337,7 +1337,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
    </section>
 
 
-   <section title="Relay node processing" anchor="sec_s_pe">
+   <section title="Relay Node Processing" anchor="sec_s_pe">
     <t>
      A DetNet Relay node operates in the DetNet forwarding sub-layer . This processing is done within an
      extended forwarder function. Whether an ingress DetNet member flow receives DetNet specific
@@ -1353,7 +1353,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     </section>
    </section>
 
-<section title="Other DetNet data plane considerations">
+<section title="Other DetNet Data Plane Considerations">
  <section title="Class of Service">
    <t>
      [Editor's note: this section needs to updated to discuss how DetNet service is
@@ -1452,7 +1452,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
   </t>
  </section>
 
- <section title="Cross-DetNet flow resource aggregation" anchor="Aggregation">
+ <section title="Cross-DetNet Flow Resource Aggregation" anchor="Aggregation">
   <t> [Editor's NOTE: Isn't this section the same as "Aggregation at the
   LSP". -- Address as part of aggregation section cleanup.]
   </t>
@@ -1495,7 +1495,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
    </t>
  </section>
 
- <section title="Layer 2 addressing and QoS Considerations">
+ <section title="Layer 2 Addressing and QoS Considerations">
   <t> [Editor's NOTE: review and simplify this section. Doesn't this
   belong in the TSN section? Alternatively, describe in generic/non
   sub-network technology specific terms.]
@@ -1762,7 +1762,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
 <!-- ===================================================================== -->
 
 <section anchor="mpls-over-tsn"
-         title="DetNet MPLS Operation over IEEE 802.1 TSN Sub-Networks">
+         title="DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks">
   <t>
   [Editor's note: this is a place holder section.  A standalone section on MPLS over IEEE
   802.1 TSN.  Includes RFC2119 Language.]
@@ -1778,7 +1778,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
 	  Note: in case of MPLS Transit node there is no DetNet Service sub-layer.</t>
 
 <figure align="center" anchor="fig_mpls_detnet_to_tsn"
-              title="DetNet Enabled MPLS Network over a TSN sub-network">
+              title="DetNet Enabled MPLS Network Over a TSN Sub-Network">
 <artwork><![CDATA[
    MPLS (DetNet)                 MPLS (DetNet)
       Node-1                        Node-2
@@ -1878,7 +1878,7 @@ Note: * no service sub-layer for transit nodes
 		</t>
 
 <figure align="center" anchor="fig_mpls_with_tsn"
-              title="MPLS (DetNet) node with TSN functions">
+              title="MPLS (DetNet) Node with TSN Functions">
 <artwork><![CDATA[
    MPLS (DetNet)
       Node-1
@@ -2057,7 +2057,7 @@ Note: * no service sub-layer for transit nodes
 <!-- ===================================================================== -->
 
 
-<section title="Security considerations">
+<section title="Security Considerations">
   <t>
    The security considerations of DetNet in general are discussed in
    <xref target="I-D.ietf-detnet-architecture"/>
@@ -2068,13 +2068,13 @@ Note: * no service sub-layer for transit nodes
 </section>
 
 
-<section anchor="iana" title="IANA considerations">
+<section anchor="iana" title="IANA Considerations">
   <t>
    This document makes no IANA requests.
   </t>
 </section>
 
-<section anchor="contributors" title="Contributors">
+<section anchor="Contributors" title="Contributors">
  <t>RFC7322 limits the number of authors listed on the front page of a draft to a maximum of 5,
   far fewer than the many individuals below who made important contributions to this draft. The
   editor wishes to thank and acknowledge each of the following authors for contributing text to
@@ -2168,7 +2168,7 @@ Note: * no service sub-layer for transit nodes
 </middle>
 
 <back>
-  <references title="Normative references">
+  <references title="Normative References">
    &rfc2119;
    <?rfc include="reference.RFC.2211"?>
    <?rfc include="reference.RFC.2212"?>
@@ -2190,7 +2190,7 @@ Note: * no service sub-layer for transit nodes
    <?rfc include="reference.RFC.8174"?>
    &I-D.ietf-spring-segment-routing-mpls;
   </references>
-  <references title="Informative references">
+  <references title="Informative References">
    <?rfc include="reference.RFC.2205"?>
    <?rfc include="reference.RFC.3272"?>
    &rfc3985;
@@ -2295,7 +2295,7 @@ Note: * no service sub-layer for transit nodes
    </reference>
 
   </references>
- <section title="Example of DetNet data plane operation" anchor="sec_comb">
+ <section title="Example of DetNet Data Plane Operation" anchor="sec_comb">
   <t>
    [Editor's note: Add a simplified example of DetNet data plane and how labels etc
    work in the case of MPLS-based PSN and utilizing PREOF. The figure is subject

--- a/draft-ietf-detnet-dp-sol-mpls-02.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-02.xml
@@ -1578,7 +1578,9 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     YANG <xref target="RFC7950"/>, and
     the Path Computation Element Communication Protocol (PCEP) <xref
     target="I-D.ietf-pce-pcep-extension-for-pce-controller"/> or any
-    combination thereof. Specific considerations and requirements for DetNet that are discussed in <xref target="control-management-requirements"/>.
+    combination thereof. Specific considerations and requirements for
+    the DetNet Controller Plane are discussed in <xref
+    target="control-management-requirements"/>.
  </t>
   <section title="S-Label and F-Label Assignment and Distribution">
    <t>

--- a/draft-ietf-detnet-dp-sol-mpls-02.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-02.xml
@@ -49,7 +49,6 @@
 <!ENTITY rfc7432 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7432.xml">
 <!ENTITY rfc7510 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7510.xml">
 <!ENTITY rfc8169 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8169.xml">
-<!ENTITY I-D.ietf-detnet-dp-alt PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-dp-alt.xml">
 <!ENTITY I-D.ietf-pce-pcep-extension-for-pce-controller PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-pce-pcep-extension-for-pce-controller.xml">
 <!ENTITY I-D.ietf-spring-segment-routing-mpls PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-spring-segment-routing-mpls">
 <!ENTITY I-D.ietf-detnet-problem-statement PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-problem-statement.xml">
@@ -63,7 +62,7 @@
   o finish discussed split/removal of foo (IP and TSN) over MPLS (Lou)
   After: All to
   o identify missing conformance language, notably WRT forwarding
-    sub-layer 
+    sub-layer
   o Aggregation section needs to be cleaned up
   o check conformance language in MPLS over TSN section
 -->
@@ -149,8 +148,8 @@
     service and forwarding sub-layer functions and supports flow identification as described in the
     DetNet Architecture.
 
-   As part of the service sub-layer functions, this document describes the
-   and how a DetNet Relay/Edge/Transit nodes works. It also describes the
+   As part of the service sub-layer functions, this document describes
+   DetNet node data plane operation. It also describes the
    function and operation of the Packet Replication (PRF) Packet Elimination
    (PEF) and Packet Ordering (POF) functions with an MPLS data plane.
 
@@ -158,8 +157,19 @@
     reduces) contention loss  and provides bounded latency for DetNet flows.
   </t>
   <t>
-   This document does not define, but does allow for, associated controller plane
-   and Operations, Administration, and Maintenance (OAM) functions.
+    MPLS encapsulated DetNet flows can be carried over
+    network technologies that can provide the DetNet required level
+    of service.  This document defines examples of such, specifically
+    carrying MPLS DetNet flows over IEEE 802.1 TSN sub-networks, and
+    over DetNet IP PSN.
+  </t>
+  <t>
+    The intent is for this document to support different traffic types
+    being mapped over DetNet MPLS, but this is out side the scope of this
+    document. An example of such can be found in <xref
+    target="I-D.ietf-detnet-dp-sol-ip"/>.  This document also allows
+    for, but does not define, associated controller plane
+    and Operations, Administration, and Maintenance (OAM) functions.
   </t>
  </section>
 
@@ -273,7 +283,7 @@
     supported by a DetNet control word (d-CW) which conforms to the
     Generic PW MPLS Control Word (PWMCW) defined in <xref
     target="RFC4385"/>.  A d-CW identifying service label (S-Label) is
-    also used. The forwarding sub-layer is supported by one or forwarding labels (F-Labels).
+    also used.
   </t>
 
  <t>
@@ -281,16 +291,300 @@
   DetNet packet which has the S-Label as top of stack uses the local context
   associated with that S-Label, for example a received F-Label, to
   determine what local DetNet operation(s) are
-  applied to that packet. An S-Label generally is unique on each edge and
-  relay node, which can be achieved by using a label taken from the platform
+  applied to that packet. An S-Label may be unique when taken from the platform
   label space <xref target="RFC3031"/>.
  </t>
 
+  <t>
+    The MPLS DetNet data plane builds on MPLS Traffic Engineering
+    encapsulations and mechanisms to provide a forwarding sub-layer that
+    is responsible for providing resource allocation and explicit
+    routes.  The forwarding sub-layer is supported by one or more
+    forwarding labels (F-Labels).
+  </t>
+
   </section>
 
-  <section title="MPLS DetNet data plane scenarios" anchor="sec_mpls_dt_dp_scen">
+  <section title="MPLS DetNet Data Plane Scenarios"
+           anchor="sec_mpls_dt_dp_scen">
 
-  <!-- imported text from draft-bryant-detnet-mpls-dp-00.txt -->
+
+      <figure align="center" anchor="fig_dn_mpls_detnet"
+              title="A DetNet MPLS Network">
+        <artwork><![CDATA[
+MPLS DetNet       Relay       Transit         Relay       MPLS DetNet
+End System        Node         Node           Node        End System
+   (T-PE)        (S-PE)       (LSR)          (S-PE)         (T-PE)
++----------+                                             +----------+
+|   Appl.  |<------------ End to End Service ----------->|   Appl.  |
++----------+   +---------+                 +---------+   +----------+
+| Service  |<--| Service |-- DetNet flow --| Service |-->| Service  |
++----------+   +---------+  +----------+   +---------+   +----------+
+|Forwarding|   |Fwd| |Fwd|  |Forwarding|   |Fwd| |Fwd|   |Forwarding|
++-------.--+   +-.-+ +-.-+  +----.---.-+   +-.-+ +-.-+   +---.------+
+        :  Link  :    /  ,-----.  \   : Link :    /  ,-----.  \
+        +........+    +-[  Sub  ]-+   +......+    +-[  Sub  ]-+
+                        [Network]                   [Network]
+                         `-----'                     `-----'
+        |<- LSP -->| |<-------- LSP -----------| |<--- LSP -->|
+
+        |<----------------- DetNet MPLS --------------------->|
+
+        ]]></artwork>
+      </figure>
+      <t>
+        <xref target="fig_dn_mpls_detnet"/> illustrates a hypothetical
+        DetNet MPLS-only network composed of DetNet aware MPLS enabled
+        end systems, operating over a DetNet aware MPLS network. In this
+        figure, relay nodes sit at MPLS LSP boundaries and transit nodes
+        are LSRs.
+      </t>
+      <t>
+        DetNet end system and relay nodes are DetNet service sub-layer
+        aware, understand the particular needs of DetNet flows and
+        provide both DetNet service and forwarding sub-layer functions.
+        They add, remove and process d-CWs, S-Labels and F-labels as
+        needed.  MPLS enabled end system and relay nodes can enhance the
+        reliability of delivery by enabling the replication of packets
+        where multiple copies, possibly over multiple paths, are
+        forwarded through the DetNet domain.  They can also eliminate
+        surplus previously replicated copies of DetNet packets. MPLS
+        DetNet nodes provide functionality similar to T-PEs when they
+        sit at the edge of an MPLS domain, and functionality similar to
+        S-PEs when they are in the middle of an MPLS domain, see <xref
+        target="RFC6073"/>.  End system and relay nodes also include
+        DetNet forwarding sub-layer functions, support for notably
+        explicit routes, and resources allocation to eliminate (or
+        reduce) congestion loss and jitter.
+      </t>
+      <t>
+        DetNet transit nodes reside wholly within a DetNet domain, and
+        also provide DetNet forwarding sub-layer functions in accordance
+        with the performance required by a DetNet flow carried over an
+        LSP. Unlike other DetNet node types, transit nodes provide no
+        service sub-layer processing.  In a DetNet MPLS network, transit
+        nodes may be DetNet service aware or may be DetNet unaware
+        MPLS Label Switching Routers (LSRs).  In this latter case, such
+        LSRs would be unaware of the special requirements of the DetNet
+        service sub-layer, but would still provide traffic engineering
+        services and the QoS need to ensure that the (TE) LSPs meet the
+        service requirements of the carried DetNet flows.
+      </t>
+
+      <t>
+        The LSPs may be provided by any MPLS controller method. For
+        example they may be provisioned via a management plane, RSVP-TE,
+        MPLS-TP, or MPLS Segment Routing (when extended to support
+        resource allocation).
+      </t>
+
+      <t>
+        <xref target="fig_pw_detnet"/> illustrates how an end to end
+        MPLS-based DetNet service is provided in a more detail.  In this
+        figure, the end systems, CE1 and CE2, are able to send and
+        receive MPLS encapsulated DetNet flows, and R1, R2 and R3 are
+        relay nodes as they sit in the middle of a DetNet network. The
+        'X' in the end systems, and relay nodes represents potential
+        DetNet compound flow packet replication and elimination points.
+        In this example, service protection is supported over four
+        DetNet member flows and TE LSPs. For a unidirectional flow, R1
+        supports PRF, R2 supports PREOF and R3 supports PEF and POF.
+        Note that the relay nodes may change the underlying forwarding
+        sub-layer, for example tunneling MPLS over IEEE 802.1 TSN <xref
+        target="mpls-over-tsn"/>, or simply over interconnect network
+        links.
+      </t>
+      <figure align="center" anchor="fig_pw_detnet"
+              title="MPLS-Based Native DetNet">
+        <artwork><![CDATA[
+      DetNet                                           DetNet
+MPLS  Service          Transit          Transit       Service MPLS
+DetNet  |             |<-Tnl->|        |<-Tnl->|            | DetNet
+End     |             V   1   V        V   2   V            | End
+System  |    +--------+       +--------+       +--------+   | System
++---+   |    |   R1   |=======|   R2   |=======|   R3   |   |  +---+
+|  X...DFa...|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|.DFa..|.X |
+|CE1|========|    \   |       |   X    |       |   /    |======|CE2|
+|   |   |    |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |  |   |
++---+        |        |=======|        |=======|        |      +---+
+    ^        +--------+       +--------+       +--------+      ^
+    |        Relay Node       Relay Node       Relay Node      |
+    |          (S-PE)           (S-PE)           (S-PE)        |
+    |                                                          |
+    |<---------------------- DetNet MPLS --------------------->|
+    |                                                          |
+    |<--------------- End to End DetNet Service -------------->|
+
+   -------------------------- Data Flow ------------------------->
+
+    X   = Optional service protection (none, PRF, PREOF, PEF/POF)
+    DFx = DetNet member flow x over a TE LSP
+]]></artwork>
+</figure>
+
+
+    <t>
+      [Authors note: TBD - should the rest of this section be cut?]
+    </t>
+
+    <t>
+      As previously mentioned, this document specifies how MPLS is used
+      to support DetNet flows using an MPLS data plane as well as how
+      such can be mapped to IEEE 802.1 TSN and IP DetNet PSNs.  In the
+      remainder of this section, sample uses of DetNet MPLS are shown
+      for illustrative purposes.  These uses are an IP DetNet, where the
+      end nodes support <xref target="I-D.ietf-detnet-dp-sol-ip"/>, and
+      an L2VPN service, where the L2 is itself an IEEE 802.1 TSN.
+    </t>
+
+    <section title="IP Over MPLS DetNet Data Plane Scenarios"
+             anchor="sec_ip_mpls_dt_dp_scen">
+
+      <figure align="center" anchor="fig_dn_ip_mpls_detnet"
+              title="DetNet (DN) IP Over MPLS Network">
+        <artwork><![CDATA[
+IP  DetNet        Relay       Transit         Relay       IP DetNet
+End System        Node         Node           Node        End System
+                  (T-PE)       (LSR)          (T-PE)
++----------+                                             +----------+
+|   Appl.  |<------------ End to End Service ----------->|   Appl.  |
++----------+   .....-----+                 +-----.....   +----------+
+| Service  |<--: Service |-- DetNet flow --| Service :-->| Service  |
++----------+   +---------+  +----------+   +---------+   +----------+
+|Forwarding|   |Fwd| |Fwd|  |Forwarding|   |Fwd| |Fwd|   |Forwarding|
++-------.--+   +-.-+ +-.-+  +----.---.-+   +-.-+ +-.-+   +---.------+
+        :  Link  :    /  ,-----.  \   : Link :    /  ,-----.  \
+        +........+    +-[  Sub  ]-+   +......+    +-[  Sub  ]-+
+                        [Network]                   [Network]
+                         `-----'                     `-----'
+
+        |<- DN IP->| |<---- DetNet MPLS ---->| |< -DN IP ->|
+        ]]></artwork>
+      </figure>
+      <t>
+        <xref target="fig_dn_ip_mpls_detnet"/> illustrates DetNet
+        enabled End Systems (hosts), connected to DetNet (DN) enabled IP
+        networks, operating over a DetNet aware MPLS network. In this
+        figure, Relay nodes sit at the boundary of the MPLS domain since
+        the non-MPLS domain is DetNet aware.  This figure is very
+        similar to <xref target="fig_dn_mpls_detnet"/>.  The primary
+        difference is that the Relay nodes are at the edges of the MPLS
+        domain and therefore function as T-PEs, and that service
+        sub-layer functions are not provided over the DetNet IP network.
+        There is no difference in transit node function.
+      </t>
+
+      <t>
+        <xref target="fig_ip_pw_detnet"/> illustrates how relay nodes
+        can provide service protection over the MPLS domain.  In this
+        case, CE1 and CE2 are IP DetNet end systems which are
+        interconnected via a MPLS domain such as previously shown in
+        <xref target="fig_pw_detnet"/>.  Note that R1 and R3 sit at the
+        edges of an MPLS domain and therefore are similar to T-PEs,
+        while R2 sits in the middle of the domain and is therefore
+        similar to an S-PE.
+      </t>
+
+      <figure align="center" anchor="fig_ip_pw_detnet"
+              title="DetNet IP over DetNet MPLS Network">
+        <artwork><![CDATA[
+      DetNet                                         DetNet
+IP    Service         Transit          Transit       Service  IP
+DetNet               |<-Tnl->|        |<-Tnl->|               DetNet
+End     |            V   1   V        V   2   V            |  End
+System  |   +--------+       +--------+       +--------+   |  System
++---+   |   |   R1   |=======|   R2   |=======|   R3   |   |   +---+
+|   |-------|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|-------|   |
+|CE1|   |   |    \   |       |   X    |       |   /    |   |   |CE2|
+|   |   |   |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |   |   |
++---+       |        |=======|        |=======|        |       +---+
+    ^       +--------+       +--------+       +--------+       ^
+    |        Relay Node       Relay Node       Relay Node      |
+    |          (T-PE)           (S-PE)          (T-PE)         |
+    |                                                          |
+    |<-DN IP-> <-------- DetNet MPLS ---------------> <-DN IP->|
+    |                                                          |
+    |<-------------- End to End DetNet Service --------------->|
+
+   -------------------------- Data Flow ------------------------->
+
+    X   = Service protection (PRF, PREOF, PEF/POF)
+    DFx = DetNet member flow x over a TE LSP
+    ]]></artwork>
+      </figure>
+
+      <figure align="center" anchor="fig_ip_mpls_detnet"
+              title="Non-DetNet aware IP Over DetNet MPLS Network">
+        <artwork><![CDATA[
+ IP               Edge                        Edge        IP
+ End System       Node                        Node        End System
+                 (T-PE)       (LSR)          (T-PE)
++----------+   +....-----+                 +-----....+   +----------+
+|   Appl.  |<--:Svc Proxy|-- E2E Service --|Svc Proxy:-->|   Appl.  |
++----------+   +.....+---+                 +---+.....+   +----------+
+|    IP    |<--:IP : |Svc|-- IP/DN Flow ---|Svc| :IP :-->|    IP    |
++----------+   +---+ +---+  +----------+   +---+ +---+   +----------+
+|Forwarding|   |Fwd| |Fwd|  |Forwarding|   |Fwd| |Fwd|   |Forwarding|
++-------.--+   +-.-+ +-.-+  +----.---.-+   +-.-+ +-.-+   +---.------+
+        :  Link  :    /  ,-----.  \   : Link :    /  ,-----.  \
+        +........+    +-[  Sub  ]-+   +......+    +-[  Sub  ]-+
+                        [Network]                   [Network]
+                         `-----'                     `-----'
+
+      |<--- IP --->| |<----- DetNet MPLS ----->| |<--- IP --->|
+      ]]></artwork>
+      </figure>
+      <t>
+        <xref target="fig_ip_mpls_detnet"/> illustrates non-DetNet
+        enabled End Systems (hosts), connected to DetNet (DN) enabled
+        MPLS network. It differs from <xref
+        target="fig_dn_ip_mpls_detnet"/> in that the hosts and edge IP
+        networks are not DetNet aware.  In this case, edge nodes sit at
+        the boundary of the MPLS domain since it is also a DetNet domain
+        boundary.  The edge nodes provide DetNet service proxies for the
+        end applications by initiating and terminating DetNet service
+        for the application's IP flows. See <xref
+        target="I-D.ietf-detnet-dp-sol-ip"/> for more information.
+      </t>
+
+      <t>
+        <xref target="fig_pw_detnet2"/> illustrates how it is still
+        possible to provided DetNet service protection for
+        non-DetNet aware end systems.  This figures is basically the
+        same as <xref target="fig_ip_pw_detnet"/>, with the exception
+        that CE1 and CE2 are non-DetNet aware end systems and E1 and E3
+        are edge nodes that replace the relay nodes R1 and R3.
+      </t>
+
+      <figure align="center" anchor="fig_pw_detnet2"
+              title="MPLS-Based DetNet (non-MPLS End System)">
+<artwork><![CDATA[
+      IP                                              IP
+Non   Service          Transit          Transit       Service Non
+DetNet                |<-Tnl->|        |<-Tnl->|              DetNet
+End     |             V   1   V        V   2   V            | End
+System  |    +--------+       +--------+       +--------+   | System
++---+   |    |   E1   |=======|   R2   |=======|   E3   |   |  +---+
+|   |--------|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|------|   |
+|CE1|   |    |    \   |       |   X    |       |   /    |   |  |CE2|
+|   |   |    |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |  |   |
++---+        |        |=======|        |=======|        |      +---+
+             +--------+       +--------+       +--------+
+             ^ Edge Node      Relay Node       Edge Node^
+             | (T-PE)           (S-PE)          (T-PE)  |
+             |                                          |
+     <--IP-->| <-------- IP Over DetNet MPLS ---------> |<--IP-->
+             |                                          |
+             |<------ End to End DetNet Service ------->|
+
+    X   = Optional service protection (none, PRF, PREOF, PEF/POF)
+    DFx = DetNet member flow x over a TE LSP
+]]></artwork>
+</figure>
+  </section>
+  <section title="IEEE 802.1 TSN Over MPLS DetNet Data Plane Scenario"
+             anchor="sec_tsn_mpls_dt_dp_scen">
+
 
 <figure anchor="fig_tsn_mpls_detnet" align="center"
 title="A TSN over DetNet MPLS Enabled Network">
@@ -316,75 +610,30 @@ title="A TSN over DetNet MPLS Enabled Network">
 </figure>
 
   <t>
-   <xref target="fig_tsn_mpls_detnet"/> shows several node types defined in <xref
-   target="I-D.ietf-detnet-architecture"/>.  DetNet
-   Edge Nodes sit at the boundary of a DetNet domain. They are responsible for
-   mapping non-DetNet aware traffic to DetNet services.  They also support
-   the imposition and disposition of the required
-   DetNet encapsulation.  These are functionally similar to pseudowire (PW)
-   Terminating Provider Edge (T-PE) nodes which use MPLS-TE LSPs.
+   <xref target="fig_tsn_mpls_detnet"/> shows IEEE 802.1 TSN end
+   stations operating over a TSN aware DetNet service running over an
+   MPLS network.  DetNet Edge Nodes sit at the boundary of a DetNet
+   domain. They are responsible for mapping non-DetNet aware traffic to
+   DetNet services.  They also support the imposition and disposition of
+   the required DetNet encapsulation.  These are functionally similar to
+   pseudowire (PW) Terminating Provider Edge (T-PE) nodes which use
+   MPLS-TE LSPs.  In this example they understand and support IEEE 802.1
+   TSN and are able to map TSN flows into DetNet flows.  The specific of
+   this operation are discussed in [TBD-TSN-OVER-DETNET].
   </t>
   <t>
 	Native TSN flow and DetNet MPLS flow differ not only by the additional MPLS specific encapsulation, but DetNet MPLS flows have
 	on each DetNet node an associated DetNet specific data structure, what defines flow related characteristics and required
-	forwarding functions. Edge Nodes MUST provide a Service Proxy entity that "associates" the DetNet flows and native flows
-	at the edge of the DetNet domain. It ensures that the DN Flow is properly served at the Edge node (and inside the domain).
+	forwarding functions. In this example, edge Nodes provide a
+        service proxy function that "associates" the DetNet flows and native flows
+	at the edge of the DetNet domain. This ensures that the DN Flow is properly served at the Edge node (and inside the domain).
   </t>
-  <t>
-   Transit nodes may be non-DetNet aware MPLS Label Switching Routers
-   (LSRs).  In this case, they
-   would be unaware of the special requirements of DetNet service information, although
-   they need to provide traffic engineering services and proper QoS to
-   the LSPs associated with DetNet flows to ensure the
-   LSPs meet the DetNet service requirements. Some implementations of
-   transit nodes may be DetNet aware, but such nodes just support the DetNet
-   forwarding sub-layer.
-  </t>
-  <t>
-   The MPLS LSP may be provided by any MPLS method (provisioned,
-   RSVP-TE, MPLS-TP, or MPLS Segment Routing (SR) when extended to
-   support resource allocation).
-  </t>
-  <figure align="center" anchor="fig_ip_mpls_detnet"
-          title="DetNet (DN) IP Over MPLS Network">
-    <artwork><![CDATA[
-IP  DetNet        Relay       Transit         Relay       IP DetNet
-End System        Node         Node           Node        End System
-                  (T-PE)       (LSR)          (T-PE)
-+----------+                                             +----------+
-|   Appl.  |<------------ End to End Service ----------->|   Appl.  |
-+----------+   .....-----+                 +-----.....   +----------+
-| Service  |<--: Service |-- DetNet flow --| Service :-->| Service  |
-+----------+   +---------+  +----------+   +---------+   +----------+
-|Forwarding|   |Fwd| |Fwd|  |Forwarding|   |Fwd| |Fwd|   |Forwarding|
-+-------.--+   +-.-+ +-.-+  +----.---.-+   +-.-+ +-.-+   +---.------+
-        :  Link  :    /  ,-----.  \   : Link :    /  ,-----.  \
-        +........+    +-[  Sub  ]-+   +......+    +-[  Sub  ]-+
-                        [Network]                   [Network]
-                         `-----'                     `-----'
 
-        |<- DN IP->| |<---- DetNet MPLS ---->| |< -DN IP ->|
-        ]]></artwork>
-  </figure>
-  <t>
-   <xref target="fig_ip_mpls_detnet"/> and <xref
-   target="fig_8021_detnet"/>, show different cases where relay nodes
-   may be used.  Relay nodes are similar to edge nodes in that both are
-   aware of the needs of particular DetNet flows and take care to
-   process them in accordance with the required performance needs.  They
-   differ in that relay nodes sit within a DetNet domain while edge
-   nodes always sit at DetNet domain boundaries.  Both node types can
-   enhance the reliability of delivery by enabling the replication of
-   packets so that multiple copies, possibly over multiple paths are
-   forwarded through the DetNet domain.  They also reduce the impact of
-   replication by eliminating surplus copies of DetNet packets.  Relay
-   nodes may sit the boundary of an MPLS domain when the non-MPLS domain
-   is DetNet aware. Relay nodes are functionally similar to PW S-PEs or,
-   when at the edge of an MPLS network, T-PEs <xref target="RFC6073"/>.
-  </t>
+
   <t>
    <xref target="fig_8021_detnet"/> illustrates how DetNet can provide services for IEEE 802.1TSN
-   end systems, CE1 and CE2, over a DetNet enabled network.  The edge nodes, E1 and E2, insert and remove required DetNet data
+   end systems, CE1 and CE2, over a DetNet enabled MPLS network.
+   Similar to <xref target="fig_ip_mpls_detnet"/>, the edge nodes, E1 and E2, insert and remove required DetNet data
    plane encapsulation.  The 'X' in the edge nodes and relay node, R1, represent a potential DetNet compound flow
    packet replication and elimination point.  This conceptually parallels L2VPN services, and could
    leverage existing related solutions as discussed below.
@@ -407,117 +656,16 @@ System |    +--------+       +--------+       +--------+   |  System
     |        Edge Node       Relay Node        Edge Node       |
     |          (T-PE)           (S-PE)          (T-PE)         |
     |                                                          |
-    |<-TSN->  <------- TSN Over DetNet MPLS --------->  <-TSN->|
+    |<- TSN -> <------- TSN Over DetNet MPLS -------> <- TSN ->|
     |                                                          |
     |<--- Emulated Time Sensitive Networking (TSN) Service --->|
 
-    DFx = DetNet Flow x
+    X   = Service protection
+    DFx = DetNet member flow x over a TE LSP
 ]]>
 </artwork>
 </figure>
-
- <t>
-    [Editor's note: TSN Over DetNet MPLS arrows extended beyond the 'X' (the PREF points).]
- </t>
-
-
- <t>
-  <xref target="fig_pw_detnet"/> illustrates how an end to end MPLS-based DetNet
-  service is provided in a more detail.  In this case, the end systems, CE1 and CE2, are able
-  to send and receive DetNet flows, and R1 and R2 are relay nodes as
-  they sit in the middle of a DetNet network.  For example, an end system sends data
-  encapsulated in MPLS.  The 'X' in the end systems, and relay nodes
-  represents potential DetNet compound flow packet replication and elimination points.
-  In this figure, the relay nodes may change the underlying forwarding sub-layer, for example
-  tunneling MPLS over IP <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>, or simply interconnect
-  network segments.
- </t>
-
-<figure align="center" anchor="fig_pw_detnet"
- title="MPLS-Based Native DetNet">
-<artwork><![CDATA[
-      DetNet                                           DetNet
-MPLS  Service          Transit          Transit       Service MPLS
-DetNet  |             |<-Tnl->|        |<-Tnl->|            | DetNet
-End     |             V   1   V        V   2   V            | End
-System  |    +--------+       +--------+       +--------+   | System
-+---+   |    |   R1   |=======|   R2   |=======|   R3   |   |  +---+
-|  X...DFa...|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|.DFa..|.X |
-|CE1|========|    \   |       |   X    |       |   /    |======|CE2|
-|   |   |    |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |  |   |
-+---+        |        |=======|        |=======|        |      +---+
-    ^        +--------+       +--------+       +--------+      ^
-    |        Relay Node       Relay Node       Relay Node      |
-    |          (S-PE)           (S-PE)           (S-PE)        |
-    |                                                          |
-    |<---------------------- DetNet MPLS --------------------->|
-    |                                                          |
-    |<--------------- End to End DetNet Service -------------->|
-]]></artwork>
-</figure>
-
- <t>
-  <xref target="fig_pw_detnet2"/> illustrates how an end to end MPLS-based DetNet
-  service is provided where the end systems are not able to send and receive
-  DetNet flows. In this example, the nodes labeled CE1 and CE2 could be
-  non-DetNet aware IP routers or hosts. Note that E1 and E2 are edge
-  nodes as they sit boundaries of the DetNet enabled domain.
- </t>
-
-<figure align="center" anchor="fig_pw_detnet2"
- title="MPLS-Based DetNet (non-MPLS End System)">
-<artwork><![CDATA[
-      IP                                              IP
-Non   Service          Transit          Transit       Service Non
-DetNet                |<-Tnl->|        |<-Tnl->|              DetNet
-End     |             V   1   V        V   2   V            | End
-System  |    +--------+       +--------+       +--------+   | System
-+---+   |    |   E1   |=======|   R2   |=======|   E3   |   |  +---+
-|   |--------|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|------|   |
-|CE1|   |    |    \   |       |   X    |       |   /    |   |  |CE2|
-|   |   |    |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |  |   |
-+---+        |        |=======|        |=======|        |      +---+
-             +--------+       +--------+       +--------+
-             ^ Edge Node      Relay Node       Edge Node^
-             | (T-PE)           (S-PE)          (T-PE)  |
-             |                                          |
-     <--IP-->| <-------- IP Over DetNet MPLS ---------> |<--IP-->
-             |                                          |
-             |<------ End to End DetNet Service ------->|
-]]></artwork>
-</figure>
- <t>
-  <xref target="fig_ip_pw_detnet"/> illustrates how end to end DetNet
-  service is provided where the end systems are able to send and receive
-  IP DetNet flows, e.g., per <xref target="I-D.ietf-detnet-dp-sol-ip"/>, and
-  the MPLS  nodes optionally provide service protection. In this
-  case R1 and R3 are T-PEs and R2 is an S-PE and the DetNet service is
-  end-to-end.
- </t>
-
-<figure align="center" anchor="fig_ip_pw_detnet"
- title="DetNet IP over DetNet (DN) MPLS">
-<artwork><![CDATA[
-      DetNet                                         DetNet
-IP    Service         Transit          Transit       Service  IP
-DetNet               |<-Tnl->|        |<-Tnl->|               DetNet
-End     |            V   1   V        V   2   V            |  End
-System  |   +--------+       +--------+       +--------+   |  System
-+---+   |   |   R1   |=======|   R2   |=======|   R3   |   |   +---+
-|   |-------|._X_....|..DF1..|.__ ___.|..DF3..|...._X_.|-------|   |
-|CE1|   |   |    \   |       |   X    |       |   /    |   |   |CE2|
-|   |   |   |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |   |   |
-+---+       |        |=======|        |=======|        |       +---+
-    ^       +--------+       +--------+       +--------+       ^
-    |        Relay Node       Relay Node       Relay Node      |
-    |          (T-PE)           (S-PE)          (T-PE)         |
-    |                                                          |
-    |<-DN IP-> <-------- DetNet MPLS ---------------> <-DN IP->|
-    |                                                          |
-    |<-------------- End to End DetNet Service --------------->|
-]]></artwork>
-</figure>
-
+  </section>
   </section>
 
   <section title="Packet flow example (service protection)">
@@ -1288,7 +1436,7 @@ Examples:
 |       DetNet Control Word       |    |    MPLS encapsulation
 +=================================+    |
 |            A-Label              |    |
-+---------------------------------+    | 
++---------------------------------+    |
 |           F-Label(s)            | <--/
 +---------------------------------+
 |           Data-Link             |
@@ -1496,7 +1644,7 @@ Examples:
    target="RFC2205">Resource ReSerVation Protocol (RSVP)</xref> (RSVP) and RSVP-TE <xref
    target="RFC3209"/> and <xref target="RFC3473"/>.  The existing MPLS mechanisms defined to
    support CoS <xref target="RFC3270"/> can also be used to reserve resources for specific traffic
-   classes. 
+   classes.
   </t>
   <t>
    A baseline set of QoS capabilities for DetNet flows carried in PWs
@@ -1790,7 +1938,7 @@ Examples:
     and associated vs co-routed bidirectional flows can be managed at the
     control level.  Note that there is no stated requirement for bidirectional
     DetNet flows to be supported using the same MPLS Labels
-    in each direction.  
+    in each direction.
      </t>
      <t>
     DetNet's use of PREOF may increase the complexity of using co-routing bidirectional flows, since if PREOF is used, then the replication points in one direction would have to match the elimination points in the other direction, and vice versa, and the optimal points for these functions in one direction may not match the optimal points in the other.
@@ -2304,7 +2452,6 @@ Note: * no service sub-layer for transit nodes
    <?rfc include="reference.RFC.7950"?>
    <?rfc include="reference.RFC.7551"?>
    <?rfc include="reference.RFC.8040"?>
-   &I-D.ietf-detnet-dp-alt;
    &I-D.ietf-pce-pcep-extension-for-pce-controller;
 &I-D.ietf-detnet-architecture;
 &I-D.ietf-detnet-flow-information-model;

--- a/draft-ietf-detnet-dp-sol-mpls-02.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-02.xml
@@ -790,68 +790,41 @@ CE1----EN1--------R1-------R2-------R3--------EN2-----CE2
 
   <t>
   The DetNet data plane also allows for the aggregation of DetNet flows, e.g., via MPLS hierarchical
-  LSPs, to improved scaling.  When DetNet flows are aggregated, transit nodes may have limited
-  ability to provide service on per-flow DetNet identifiers. Therefore, identifying each individual
-  DetNet flow on a transit node may not be achieved in some network scenarios, but DetNet service
-  can still be assured in these scenarios through resource allocation and control.
+  LSPs, to improved scaling.  When DetNet flows are aggregated, transit
+  nodes provide service to the aggregate and not on a per-DetNet flow
+  basis.  In this case, nodes performing aggregation will ensure that
+  per-flow service requirements are achieved.
  </t>
 
- <section title="End-system specific considerations">
+ <section title="End-System Specific Considerations">
   <t>
    Data-flows requiring DetNet service are generated and terminated on
-   end-systems. Encapsulation depends on application and its preferences. In a
-   DetNet (or even a TSN) domain the DN (TSN) functions use at most two flow
-   parameters, namely Flow-ID and Sequence Number. However, an application may
-   exchange further flow related parameters (e.g., time-stamp), which are not
-   considered by DN functions.
-  </t>
-
-  <t> Two types of end-systems are distinguished:
-  <list style="symbols">
-	<t> L2 (Ethernet) end-system: application directly over L2.</t>
-	<t> L3 (IP) end-system: application over L3.</t>
-    </list>
+   end-systems. Encapsulation depends on application and its
+   preferences. In a DetNet MPLS domain the DN functions use the d-CWs,
+   S-Labels and F-Labels to provide DetNet services. However, an
+   application may exchange further flow related parameters (e.g.,
+   time-stamp), which are not provided by DN functions.
   </t>
 
   <t>
-   Note: An MPLS DetNet end system (as shown in <xref target="fig_pw_detnet"/>) can be treated
-   as a combination of an L3 (IP) end-system and an MPLS DetNet edge node.
+    Specifics related to non-MPLS DetNet end station behavior are out
+    side the scope of this document.  For example, details on support
+    for DetNet IP data flows can be found in <xref
+    target="I-D.ietf-detnet-dp-sol-ip"/>. This document is also useful
+    for end stations that map IP flows to DetNet flows.
   </t>
-
   <t>
-   In case of Ethernet end-systems the application data is encapsulated directly
-   in L2. From the DN domain perspective no upper layer protocols are visible.
-   The Data-flow uses only Ethernet tag(s) and further flow specific parameters
-   (if needed) are hidden inside the protocol data unit (PDU).
+   As a general rule, DetNet MPLS domains are capable of forwarding any
+   DetNet MPLS flows and the DetNet domain does not mandate the
+   end-system or edge system encapsulation format. Unless there is a
+   proxy of some form present, end-systems peer with similar end-systems
+   using the same application encapsulation format.  For example, as
+   shown in <xref target="fig_es_connect"/>, IP applications peer with
+   IP applications and Ethernet L2VPN applications peer with Ethernet
+   L2VPN applications.
   </t>
 
-  <t>
-   The IP end-system scenario is different. In this case, data-flows are
-   encapsulated directly in IP and, typically, other higher layer
-   protocols such as UDP and Real-time Transport Protocol (RTP).
-   Many valid combinations exist and it is up to applications to select
-   specific headers to be used. Details on support for DetNet IP data
-   flows can be found in <xref target="I-D.ietf-detnet-dp-sol-ip"/>.
-  </t>
-
-  <t>
-   As a general rule, DetNet domains MUST be capable of forwarding any Data-flows
-   and the DetNet domain MUST NOT mandate the end-system encapsulation
-   format.
-  </t>
-
-  <t>
-   Furthermore, no application-level-proxy function is envisioned inside the
-   DetNet domain, so end-systems peer with end-systems using the same
-   application encapsulation format (see figure below):
-
-   <list style="symbols">
-	<t> L2 end-systems peer with L2 end-systems and </t>
-	<t> L3 end-systems peer with L3 end-systems.</t>
-    </list>
-  </t>
-
-  <figure title="End-systems and the DetNet domain" anchor="fig_es_connect">
+  <figure title="End-Systems and the DetNet MPLS Domain" anchor="fig_es_connect">
   <artwork align="center"><![CDATA[
 +-----+
 |  X  |                               +-----+
@@ -865,7 +838,7 @@ CE1----EN1--------R1-------R2-------R3--------EN2-----CE2
           \                             |
           0========= tunnel-2 =========0
          / \                        __/ \
-  +-----+   \__     DetNet domain  /     \
+  +-----+   \__ MPLS DetNet domain /     \
   |  X  |      \         __       /       +-----+
   +-----+       \_______/  \_____/        |  X  |
   |  IP |                                 +-----+
@@ -875,250 +848,47 @@ CE1----EN1--------R1-------R2-------R3--------EN2-----CE2
     </artwork></figure>
 
  </section>
+ <section title="Sub-Network Considerations">
+   <t>
+     As shown in <xref target="fig_dn_mpls_detnet"/>, MPLS nodes are
+     interconnected by different sub-network technologies, which may
+     include point-to-point links. Each of these need to provide
+     appropriate service to DetNet flows.  In some cases, e.g., on
+     dedicated point-to-point links or TDM technologies, all that is
+     required is for a DetNet node to appropriately queue its output
+     traffic.  In other cases, DetNet nodes will need to map DetNet
+     flows to the flow semantics (i.e., identifiers) and mechanisms used
+     by an underlying sub-network technology.  <xref
+     target="fig_dn_mpls_sn_ex"/> shows several examples of header
+     formats that can be used to carry DetNet MPLS flows over different
+     sub-network technologies.  L2 represent a generic layer-2
+     encapsulation that might be used on a point-to-point link.  TSN
+     represents the encapsulation used on an IEEE 802.1 TSN network, as
+     described in <xref target="mpls-over-tsn"/>.  UDP/IP represents the
+     encapsulation used on a DetNet IP PSN, as described in <xref
+     target="mpls-over-ip"/> .     
+   </t>
+   
 
- <section title="DetNet domain specific considerations">
-
-  <t> From a connection type perspective, three scenarios are distinguished:
-    <list style="numbers">
-	<t>
-     Directly attached: end-system is directly connected to an edge node.
-    </t>
-	<t>
-     Indirectly attached: end-system is behind a (L2-TSN / L3-DetNet)
-     sub-network.
-    </t>
-	<t>
-     DN integrated: end-system is part of the DetNet domain.
-    </t>
-    </list>
-  </t>
-
-  <t>
-   L3 end-systems may use any of these connection types, however L2 end-systems
-   may use only the first two (directly or indirectly attached). DetNet domain
-   MUST allow communication between any end-systems of the same type (L2-L2,
-   L3-L3), independent of their connection type and DetNet capability. However
-   directly attached and indirectly attached end-systems have no knowledge about
-   the DetNet domain and its encapsulation format at all. See <xref target="fig_es_con_types"/>
-   for L3 end-system scenarios.
-  </t>
-
-  <figure title="Connection types of L3 end-systems" anchor="fig_es_con_types">
-  <artwork align="center"><![CDATA[
-                                   ____+----+
-           +----+        _____    /    | ES3|
-           | ES1|____   /     \__/     +----+___
-           +----+    \ /                        \
-                      +                          |
-              ____     \                        _/
-+----+     __/    \     +__    DetNet domain   /
-| ES2|____/  L2/L3 |___/   \         __     __/
-+----+    \_______/         \_______/  \___/
-
-  ]]>
-    </artwork></figure>
-
-
- <section title="DetNet Layer Two Service">
-
-  <t>
-   The simplest DetNet service is to provide tunneling for layer two,
-   where the connected hosts are in the same broadcast (BC) domain. Forwarding
-   over the DetNet domain is based on L2 (MAC) addresses (i.e. dst-MAC),
-   or on received interface <xref target="RFC3985"/>. In both cases
-   the L2 headers MUST either be kept, or provision must be made for their
-   reconstruction at egress from the DetNet domain.
-  </t>
-
-  <figure title="Encapsulation format for DetNet Layer Two Service" anchor="fig_encap_DN_bridging">
-  <artwork align="center"><![CDATA[
-                     +------+
-                     |  X   |
-            +------+ +------+
-            |  X   | |  IP  |
-            +------+ +------+
-End-system  |  L2  | |  L2  |
-      +-----+======+-+======+--+------+
-DetNet tunnel                  | Shim |
-                               +------+
-                               | MPLS |
-                               +------+
-                               |  L2  |
-                               +------+
-
-Examples:
-
-                      +------+  +------+
-                      |  X   |  |  X   |
-            +------+  +------+  +------+
-            |  X   |  |  IP  |  |  IP  |
-            +------+  +------+  +------+
-            |  L2  |  |  L2  |  |  L2  |
-      +-----+======+--+======+--+======+-----+
-            | d-CW |  | d-CW |  | d-CW |
-            +------+  +------+  +------+
-            | MPLS |  | MPLS |  | MPLS |
-            +------+  +------+  +------+
-            |  L2  |  |  L2  |  | UDP  |
-            +------+  +------+  +------+
-                                |  IP  |
-                                +------+
-                                |  L2  |
-                                +------+
-  ]]>
-    </artwork></figure>
-
-  <t>
-   As shown in <xref target="fig_encap_DN_bridging"/> both L2 and L3 end-systems
-   can be served by such a DetNet L2  encapsulation service.
-   This encapsulation service may be carried over MPLS natively  <xref target="pwSolution"/>, or over MPLS over IP
-   <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>.
-  </t>
-  </section>
-
- <section title="DetNet Routing Service (IP over MPLS)" anchor="detrouting">
-
-  <t>
-   IP traffic and IP DetNet flows, see <xref
-   target="I-D.ietf-detnet-dp-sol-ip"/>, can be carried over a DetNet
-   MPLS domain.  In such cases, the IP headers are modified per standard
-   router behavior, e.g., TTL handling. <xref target="fig_mpls_DN_routing"/> shows the
-   encapsulation of an IP flow over MPLS as well as when MPLS is carried
-   over an IP PSN, see <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>.
-  </t>
-
-  <figure title="Encapsulation format for DetNet Routing in MPLS PSN for L3 end-systems" anchor="fig_mpls_DN_routing">
+  <figure title="Example DetNet MPLS Sub-Network Formats" anchor="fig_dn_mpls_sn_ex">
   <artwork align="center"><![CDATA[
 
-
-            +------+
-            |  X   |
-            +------+
-End-system  |  IP  |
-      +-----+======+--+------+
-DetNet tunnel         | Shim |
-                      +------+
-                      | MPLS |
-                      +------+
-                      |  L2  |
-                      +------+
-
-Examples:
-
-            +------+  +------+
-            |  X   |  |  X   |
-            +------+  +------+
-            |  IP  |  |  IP  |
-      +-----+======+--+======+-----+
-            | d-CW |  | d-CW |
-            +------+  +------+
-            | MPLS |  | MPLS |
-            +------+  +------+
-            |  L2  |  | UDP  |
-            +------+  +------+
-                      |  IP  |
-                      +------+
-                      |  L2  |
-                      +------+
-  ]]>
+                   +------+  +------+  +------+
+App-Flow           |  X   |  |  X   |  |  X   |
+             +-----+======+--+======+--+======+-----+
+DetNet-MPLS        | d-CW |  | d-CW |  | d-CW |
+                   +------+  +------+  +------+
+                   |Labels|  |Labels|  |Labels|
+             +-----+======+--+======+--+======+-----+
+Sub-Network        |  L2  |  | TSN  |  | UDP  |
+                   +------+  +------+  +------+
+                                       |  IP  |
+                                       +------+
+                                       |  L2  |
+                                       +------+
+    ]]>
   </artwork></figure>
-
  </section>
-</section>
-
-
-<section title="DetNet Inter-Working Function (DN-IWF)">
-
-<section title="Networks with multiple technology segments" anchor="nwsegments">
-
-  <t>
-   There are networking scenarios, where the DetNet domain contains multiple technology segments (IP,
-   MPLS, ..) and all those segments are under the same administrative control (see <xref
-   target="fig_pref_xcrs_segments"/>). Furthermore, DetNet nodes may be interconnected via TSN
-   segments.
-  </t>
-
-  <t> An important aspect of DetNet network design is the placement of DetNet functions across the
-  domain. Designs based on segment-by-segment optimization can provide only sub-optimal solutions. In
-  order to achieve global optimized Inter-Working Functions (DN-IWF) can be
-  placed at segment edge
-  nodes, which stitch together DetNet flows across connected segments.    </t>
-
-  <t> DN-IWF may ensure that flow attributes are correlated across segment edges. For example,
-  there are two DetNet functions which require Sequence Numbers: (1) PEF: removes duplications
-  from flows and (2) POF: ensures in-order-delivery of packet in a flow. Stitching flows together
-  and correlating attributes means for example that replication of packets can happen in one segment
-  and elimination of duplicates in a different one.   </t>
-
-  <figure title="Optimal replication and elimination placement across technology segments example" anchor="fig_pref_xcrs_segments">
-  <artwork align="center"><![CDATA[
-                                   ______
-                         ____     /      \__
-            ____        /     \__/          \___   ______
-+----+   __/    +======+                       +==+      \     +----+
-|src |__/  Seg1  )     |                       |  \  Seg3 \____| dst|
-+----+  \_______+      \       Segment-2       |   \+_____/    +----+
-                 \======+_                    _+===/
-                          \         __     __/
-                           \_______/  \___/
-
-
-                                       +------------+
-             +---------------E----+    |            |
-+----+       |               |    +----R---+        |          +----+
-|src |-------R           +---+             |        E----------+ dst|
-+----+       |           |                 E--------+          +----+
-             +-----------R                 |
-                         +-----------------+
-  ]]>
-    </artwork></figure>
-
-</section>
-<section title="DN-IWF related considerations">
-
-  <t> The goal of DN-IWF is to (1) match and (2) translate segment specific flow attributes. The DN-IWF ensures that segment specific attributes comprise per domain unique attributes for the whole DetNet domain. This characteristic can ensure that DetNet functions can be based on per domain attributes and not per segment attributes.
-  </t>
-
-  <t> The two DetNet specific attributes have the following characteristics:
-  <list style="symbols">
-   <t> Flow-ID: it is same in all packets of a flow </t>
-   <t> Sequence Number: it is different packet-by-packet </t>
-  </list>
-  </t>
-
-  <t> For the Flow-ID the DN-IWF can implement a static mapping. The situation is more complicated for Sequence Number as it is different packet-by-packet, so it may need more sophisticated translation unless its format is exactly the same in the two technology segments. In this later case the DN-IWF can simple copy the Sequence Number field between the tunneling encapsulation of the two technology segments.
-  </t>
-
-  <t> In case of three technology segments (IP, MPLS and TSN) three DN-IWF functions can be specified. In the rest of this section the focus is on the (1) IP - MPLS network scenario. Note: the use-cases are out-of-scope for (2) TSN - IP, (3) TSN - MPLS.
-  </t>
-
-  <t> Simplest implementation of DN-IWF is provided if the flow attributes have the same format. Such a common denominator of the tunnel encapsulation format is the pseudowire encapsulation over both IP and MPLS.
-  </t>
-
-  <figure title="FIGURE Placeholder PW over X" anchor="fig_pwox_enc">
-  <artwork align="center"><![CDATA[
-   +--------+
-   |        |
-   | X    X |
-   |  ____  |
-   | /    \ |
-   |        |
-   |/\/\/\/\|
-
-      Oops!
- 404 Not Found
-  ]]>
-    </artwork></figure>
-
-    <t>
-      [Editor's note: Where is the text describing how 802.1 TSN Streams are
-      mapping to DetNet services/flows. i.e., EVPN+]
-    </t>
-</section>
-
-
-</section>
-
 </section>
 
 <!-- ================================================================= -->
@@ -1394,7 +1164,7 @@ Examples:
    </t>
    <section anchor="aggregation-at-the-lsp" title="Aggregation at the LSP">
     <t>
-     DetNet flows forwarded via MPLS can leverage MPLS-TE?s existing
+     DetNet flows forwarded via MPLS can leverage MPLS-TE's existing
      support for hierarchical LSPs (H-LSPs), see <xref target="RFC4206"/>.  H-LSPs are
      typically used to aggregate control and resources, they may also be
      used to provide OAM or protection for the aggregated LSPs.  Arbitrary
@@ -1985,30 +1755,11 @@ Examples:
  </section>
 </section>
 
-<!-- ===================================================================== -->
-
-<section anchor="ip-over-detnet"
-         title="DetNet IP Operation over DetNet MPLS Service">
-  <t>
-  [Editor's note: this is a place holder section.  A standalone section on
-  operation of IP flows over DetNet MPLS data plane.  Includes RFC2119 Language.]
-  </t>
-</section>
-
-<!-- ===================================================================== -->
-
-<section anchor="tsn-over-detnet"
-         title="IEEE 802.1 TSN Interconnection over DetNet MPLS Service">
-  <t>
-  [Editor's note: this is a place holder section.  A standalone section on TSN
-  "island" interconnect over DetNet".  Includes RFC2119 Language.]
-  </t>
-</section>
 
 <!-- ===================================================================== -->
 
 <section anchor="mpls-over-tsn"
-         title="DetNet MPLS Forwarding Sub-Layer Operation over IEEE 802.1 TSN Sub-Networks">
+         title="DetNet MPLS Operation over IEEE 802.1 TSN Sub-Networks">
   <t>
   [Editor's note: this is a place holder section.  A standalone section on MPLS over IEEE
   802.1 TSN.  Includes RFC2119 Language.]
@@ -2182,7 +1933,7 @@ Note: * no service sub-layer for transit nodes
 
 <!-- ===================================================================== -->
 
-<section anchor="detnet-data-plane-encapsulation-for-ip-transport-networks" title="DetNet MPLS Forwarding Sub-Layer Operation over IP DetNet PSNs">
+<section anchor="mpls-over-ip" title="DetNet MPLS Operation over IP DetNet PSNs">
  <t>
   This section specifies the DetNet encapsulation over an IP network.
   The approach is modeled on the operation of MPLS and PseudoWires (PW) over
@@ -2243,7 +1994,7 @@ Note: * no service sub-layer for transit nodes
  <t>
   As in <xref target="pwSolution"/>, the S-Label is used to identify a DetNet flow
   to the peer node that processes it, in this case the node addressed by the
-  IP Header in <xref target="IP-encap-dn"/>. The S-Label is allocated from the receiving node?s
+  IP Header in <xref target="IP-encap-dn"/>. The S-Label is allocated from the receiving node's
   platform label space <xref target="RFC3031"/>.
  </t>
  <t>
@@ -2322,7 +2073,7 @@ Note: * no service sub-layer for transit nodes
 
 <section anchor="contributors" title="Contributors">
  <t>RFC7322 limits the number of authors listed on the front page of a draft to a maximum of 5,
-  far fewer than the 20 individuals below who made important contributions to this draft. The
+  far fewer than the many individuals below who made important contributions to this draft. The
   editor wishes to thank and acknowledge each of the following authors for contributing text to
   this draft. See also <xref target="acks"/>.
  </t>

--- a/draft-ietf-detnet-dp-sol-mpls-02.xml
+++ b/draft-ietf-detnet-dp-sol-mpls-02.xml
@@ -1083,7 +1083,7 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
     that only one encapsulation type will be present for each DetNet flow.
     Of course, if for some reason the multiple encapsulations are needed
     to support a single DetNet service, multiple S-Labels will be
-    required for that service.  Note that in the unlikely case that Ipv4
+    required for that service.  Note that in the unlikely case that IPv4
     and IPv6 will map to the same DetNet flow, different S-Labels will be
     needed to differentiate between the versions of IP.
    </t>
@@ -1706,7 +1706,8 @@ Sub-Network        |  L2  |  | TSN  |  | UDP  |
   <t>
     While the MPLS data plane must support bidirectional DetNet flows,
     there are no special bidirectional features with respect to the data plane
-    other than the need for the two directions take the same paths.  Fate sharing
+    other than the need for the two directions of a co-routed
+    bidirectional flow to take the same path.  Fate sharing
     and associated vs co-routed bidirectional flows can be managed at the
     control level.  Note that there is no stated requirement for bidirectional
     DetNet flows to be supported using the same MPLS Labels

--- a/text-to-be-moved
+++ b/text-to-be-moved
@@ -1,0 +1,266 @@
+      
+ <section title="DetNet domain specific considerations">
+
+  <t> From a connection type perspective, three scenarios are distinguished:
+    <list style="numbers">
+	<t>
+     Directly attached: end-system is directly connected to an edge node.
+    </t>
+	<t>
+     Indirectly attached: end-system is behind a (L2-TSN / L3-DetNet)
+     sub-network.
+    </t>
+	<t>
+     DN integrated: end-system is part of the DetNet domain.
+    </t>
+    </list>
+  </t>
+
+  <t>
+   L3 end-systems may use any of these connection types, however L2 end-systems
+   may use only the first two (directly or indirectly attached). DetNet domain
+   MUST allow communication between any end-systems of the same type (L2-L2,
+   L3-L3), independent of their connection type and DetNet capability. However
+   directly attached and indirectly attached end-systems have no knowledge about
+   the DetNet domain and its encapsulation format at all. See <xref target="fig_es_con_types"/>
+   for L3 end-system scenarios.
+  </t>
+
+  <figure title="Connection types of L3 end-systems" anchor="fig_es_con_types">
+  <artwork align="center"><![CDATA[
+                                   ____+----+
+           +----+        _____    /    | ES3|
+           | ES1|____   /     \__/     +----+___
+           +----+    \ /                        \
+                      +                          |
+              ____     \                        _/
++----+     __/    \     +__    DetNet domain   /
+| ES2|____/  L2/L3 |___/   \         __     __/
++----+    \_______/         \_______/  \___/
+
+  ]]>
+    </artwork></figure>
+
+
+ <section title="DetNet Layer Two Service">
+
+  <t>
+   The simplest DetNet service is to provide tunneling for layer two,
+   where the connected hosts are in the same broadcast (BC) domain. Forwarding
+   over the DetNet domain is based on L2 (MAC) addresses (i.e. dst-MAC),
+   or on received interface <xref target="RFC3985"/>. In both cases
+   the L2 headers MUST either be kept, or provision must be made for their
+   reconstruction at egress from the DetNet domain.
+  </t>
+
+  <figure title="Encapsulation format for DetNet Layer Two Service" anchor="fig_encap_DN_bridging">
+  <artwork align="center"><![CDATA[
+                     +------+
+                     |  X   |
+            +------+ +------+
+            |  X   | |  IP  |
+            +------+ +------+
+End-system  |  L2  | |  L2  |
+      +-----+======+-+======+--+------+
+DetNet tunnel                  | Shim |
+                               +------+
+                               | MPLS |
+                               +------+
+                               |  L2  |
+                               +------+
+
+Examples:
+
+                      +------+  +------+
+                      |  X   |  |  X   |
+            +------+  +------+  +------+
+            |  X   |  |  IP  |  |  IP  |
+            +------+  +------+  +------+
+            |  L2  |  |  L2  |  |  L2  |
+      +-----+======+--+======+--+======+-----+
+            | d-CW |  | d-CW |  | d-CW |
+            +------+  +------+  +------+
+            | MPLS |  | MPLS |  | MPLS |
+            +------+  +------+  +------+
+            |  L2  |  |  L2  |  | UDP  |
+            +------+  +------+  +------+
+                                |  IP  |
+                                +------+
+                                |  L2  |
+                                +------+
+  ]]>
+    </artwork></figure>
+
+  <t>
+   As shown in <xref target="fig_encap_DN_bridging"/> both L2 and L3 end-systems
+   can be served by such a DetNet L2  encapsulation service.
+   This encapsulation service may be carried over MPLS natively  <xref target="pwSolution"/>, or over MPLS over IP
+   <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>.
+  </t>
+  </section>
+
+ <section title="DetNet Routing Service (IP over MPLS)" anchor="detrouting">
+
+  <t>
+   IP traffic and IP DetNet flows, see <xref
+   target="I-D.ietf-detnet-dp-sol-ip"/>, can be carried over a DetNet
+   MPLS domain.  In such cases, the IP headers are modified per standard
+   router behavior, e.g., TTL handling. <xref target="fig_mpls_DN_routing"/> shows the
+   encapsulation of an IP flow over MPLS as well as when MPLS is carried
+   over an IP PSN, see <xref target="detnet-data-plane-encapsulation-for-ip-transport-networks"/>.
+  </t>
+
+  <figure title="Encapsulation format for DetNet Routing in MPLS PSN for L3 end-systems" anchor="fig_mpls_DN_routing">
+  <artwork align="center"><![CDATA[
+
+
+            +------+
+            |  X   |
+            +------+
+End-system  |  IP  |
+      +-----+======+--+------+
+DetNet tunnel         | Shim |
+                      +------+
+                      | MPLS |
+                      +------+
+                      |  L2  |
+                      +------+
+
+Examples:
+
+            +------+  +------+
+            |  X   |  |  X   |
+            +------+  +------+
+            |  IP  |  |  IP  |
+      +-----+======+--+======+-----+
+            | d-CW |  | d-CW |
+            +------+  +------+
+            | MPLS |  | MPLS |
+            +------+  +------+
+            |  L2  |  | UDP  |
+            +------+  +------+
+                      |  IP  |
+                      +------+
+                      |  L2  |
+                      +------+
+  ]]>
+  </artwork></figure>
+
+ </section>
+</section>
+
+
+
+<section title="DetNet Inter-Working Function (DN-IWF)">
+
+<section title="Networks with multiple technology segments" anchor="nwsegments">
+
+  <t>
+   There are networking scenarios, where the DetNet domain contains multiple technology segments (IP,
+   MPLS, ..) and all those segments are under the same administrative control (see <xref
+   target="fig_pref_xcrs_segments"/>). Furthermore, DetNet nodes may be interconnected via TSN
+   segments.
+  </t>
+
+  <t> An important aspect of DetNet network design is the placement of DetNet functions across the
+  domain. Designs based on segment-by-segment optimization can provide only sub-optimal solutions. In
+  order to achieve global optimized Inter-Working Functions (DN-IWF) can be
+  placed at segment edge
+  nodes, which stitch together DetNet flows across connected segments.    </t>
+
+  <t> DN-IWF may ensure that flow attributes are correlated across segment edges. For example,
+  there are two DetNet functions which require Sequence Numbers: (1) PEF: removes duplications
+  from flows and (2) POF: ensures in-order-delivery of packet in a flow. Stitching flows together
+  and correlating attributes means for example that replication of packets can happen in one segment
+  and elimination of duplicates in a different one.   </t>
+
+  <figure title="Optimal replication and elimination placement across technology segments example" anchor="fig_pref_xcrs_segments">
+  <artwork align="center"><![CDATA[
+                                   ______
+                         ____     /      \__
+            ____        /     \__/          \___   ______
++----+   __/    +======+                       +==+      \     +----+
+|src |__/  Seg1  )     |                       |  \  Seg3 \____| dst|
++----+  \_______+      \       Segment-2       |   \+_____/    +----+
+                 \======+_                    _+===/
+                          \         __     __/
+                           \_______/  \___/
+
+
+                                       +------------+
+             +---------------E----+    |            |
++----+       |               |    +----R---+        |          +----+
+|src |-------R           +---+             |        E----------+ dst|
++----+       |           |                 E--------+          +----+
+             +-----------R                 |
+                         +-----------------+
+  ]]>
+    </artwork></figure>
+
+</section>
+<section title="DN-IWF related considerations">
+
+  <t> The goal of DN-IWF is to (1) match and (2) translate segment specific flow attributes. The DN-IWF ensures that segment specific attributes comprise per domain unique attributes for the whole DetNet domain. This characteristic can ensure that DetNet functions can be based on per domain attributes and not per segment attributes.
+  </t>
+
+  <t> The two DetNet specific attributes have the following characteristics:
+  <list style="symbols">
+   <t> Flow-ID: it is same in all packets of a flow </t>
+   <t> Sequence Number: it is different packet-by-packet </t>
+  </list>
+  </t>
+
+  <t> For the Flow-ID the DN-IWF can implement a static mapping. The situation is more complicated for Sequence Number as it is different packet-by-packet, so it may need more sophisticated translation unless its format is exactly the same in the two technology segments. In this later case the DN-IWF can simple copy the Sequence Number field between the tunneling encapsulation of the two technology segments.
+  </t>
+
+  <t> In case of three technology segments (IP, MPLS and TSN) three DN-IWF functions can be specified. In the rest of this section the focus is on the (1) IP - MPLS network scenario. Note: the use-cases are out-of-scope for (2) TSN - IP, (3) TSN - MPLS.
+  </t>
+
+  <t> Simplest implementation of DN-IWF is provided if the flow attributes have the same format. Such a common denominator of the tunnel encapsulation format is the pseudowire encapsulation over both IP and MPLS.
+  </t>
+
+  <figure title="FIGURE Placeholder PW over X" anchor="fig_pwox_enc">
+  <artwork align="center"><![CDATA[
+   +--------+
+   |        |
+   | X    X |
+   |  ____  |
+   | /    \ |
+   |        |
+   |/\/\/\/\|
+
+      Oops!
+ 404 Not Found
+  ]]>
+    </artwork></figure>
+
+    <t>
+      [Editor's note: Where is the text describing how 802.1 TSN Streams are
+      mapping to DetNet services/flows. i.e., EVPN+]
+    </t>
+</section>
+
+
+</section>
+
+</section>
+
+<!-- ===================================================================== -->
+
+<section anchor="ip-over-detnet"
+         title="DetNet IP Operation over DetNet MPLS Service">
+  <t>
+  [Editor's note: this is a place holder section.  A standalone section on
+  operation of IP flows over DetNet MPLS data plane.  Includes RFC2119 Language.]
+  </t>
+</section>
+
+<!-- ===================================================================== -->
+
+<section anchor="tsn-over-detnet"
+         title="IEEE 802.1 TSN Interconnection over DetNet MPLS Service">
+  <t>
+  [Editor's note: this is a place holder section.  A standalone section on TSN
+  "island" interconnect over DetNet".  Includes RFC2119 Language.]
+  </t>
+</section>


### PR DESCRIPTION
Sent in mail:

    I went through the MPLS document with an eye towards conformance
language and identifying what needs to be done to finalize the document
and have a proposal - I think we should reduce the scope of the document
and cover only the the behavior of the MPLS(w/PW) data plane and how it
maps to lower layer networks, specifically TSN.  This would simplify the
document by moving any XYZ (TSN or IP) to separate documents, and make
it unambiguous what a conformant implementation needs to do. The IP
document would likewise only cover behaviors at the IP layer and mapping
to TSN and DetNet/MPLS layers. And a new document would over TSN over
DetNet MPLS.